### PR TITLE
initial UI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ clouddriver-oracle-bmcs/bmcs-sdk
 gatling.conf
 .DS_Store
 /plugins/
+node_modules
+yarn.lock

--- a/k8s-plugin-deck/.eslintrc.js
+++ b/k8s-plugin-deck/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@spinnaker/pluginsdk/pluginconfig/eslintrc');

--- a/k8s-plugin-deck/.prettierrc.js
+++ b/k8s-plugin-deck/.prettierrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@spinnaker/pluginsdk/pluginconfig/prettierrc.js');

--- a/k8s-plugin-deck/k8s-plugin-deck.gradle
+++ b/k8s-plugin-deck/k8s-plugin-deck.gradle
@@ -1,0 +1,1 @@
+apply plugin: "io.spinnaker.plugin.ui-extension"

--- a/k8s-plugin-deck/package.json
+++ b/k8s-plugin-deck/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "k8s-plugin-deck",
+  "version": "1.0.0",
+  "private": true,
+  "module": "build/dist/index.js",
+  "scripts": {
+    "clean": "npx shx rm -rf build",
+    "develop": "npm run clean && run-p watch proxy",
+    "build": "npm run clean && NODE_ENV=production rollup -c",
+    "lint": "eslint --ext js,jsx,ts,tsx src",
+    "postinstall": "check-plugin && check-peer-dependencies || true",
+    "prettier": "prettier --write 'src/**/*.{js,jsx,ts,tsx,html,css,less,json}'",
+    "proxy": "dev-proxy",
+    "watch": "rollup -c -w --no-watch.clearScreen"
+  },
+  "dependencies": {
+    "@spinnaker/core": "0.0.563",
+    "@spinnaker/pluginsdk": "0.0.26",
+    "@spinnaker/pluginsdk-peerdeps": "0.0.11",
+    "@spinnaker/presentation": "0.0.4",
+    "@uirouter/core": "6.0.4",
+    "@uirouter/react": "1.0.2",
+    "lodash-es": "4.17.15",
+    "prop-types": "15.6.1",
+    "react": "16.14.0",
+    "react-dom": "16.14.0",
+    "rxjs": "5.6.0-forward-compat.5"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "16.0.0",
+    "@rollup/plugin-json": "4.1.0",
+    "@rollup/plugin-node-resolve": "10.0.0",
+    "@rollup/plugin-replace": "2.4.2",
+    "@rollup/plugin-typescript": "6.1.0",
+    "@rollup/plugin-url": "6.0.0",
+    "@spinnaker/eslint-plugin": "1.0.13",
+    "@types/react": "16.8.25",
+    "@typescript-eslint/eslint-plugin": "4.4.0",
+    "@typescript-eslint/parser": "4.4.0",
+    "bufferutil": "4.0.2",
+    "eslint": "7.10.0",
+    "eslint-config-prettier": "6.12.0",
+    "eslint-plugin-react-hooks": "4.1.2",
+    "husky": "1.3.1",
+    "npm-run-all": "4.1.5",
+    "prettier": "2.1.2",
+    "pretty-quick": "3.1.0",
+    "rollup": "2.33.1",
+    "rollup-plugin-external-globals": "0.6.1",
+    "rollup-plugin-less": "1.1.2",
+    "rollup-plugin-postcss": "3.1.8",
+    "rollup-plugin-terser": "7.0.2",
+    "rollup-plugin-visualizer": "4.2.2",
+    "shx": "0.3.3",
+    "typescript": "4.3.0-dev.20210409",
+    "utf-8-validate": "5.0.3"
+  },
+  "files": [
+    "build/dist"
+  ]
+}

--- a/k8s-plugin-deck/rollup.config.js
+++ b/k8s-plugin-deck/rollup.config.js
@@ -1,0 +1,6 @@
+const basePluginConfig = require('@spinnaker/pluginsdk/pluginconfig/rollup.config');
+
+export default {
+  ...basePluginConfig,
+  input: 'src/index.ts',
+};

--- a/k8s-plugin-deck/src/handlers/k8sHandler.ts
+++ b/k8s-plugin-deck/src/handlers/k8sHandler.ts
@@ -10,11 +10,8 @@ class k8sResourceHandler implements IResourceKindConfig {
 
     public displayLink(): ((resource: IManagedResourceSummary) => string) {
         return function (resource: IManagedResourceSummary) {
-            const baseUrl = `${window.location.protocol}//${window.location.host}`
-            // const path = `#/applications/${resource.moniker?.app}/loadBalancers`
-            // currently k8s plugin doesn't return moniker field
-            const path = `#/applications/moretest/loadBalancers`
-            const params = `?acct=${resource.locations.account}`
+            const path = `#/applications/${resource.moniker?.app}/loadBalancers`
+            const params = `?acct=${resource.locations?.account}`
             return `${path}${params}`
         }
     }

--- a/k8s-plugin-deck/src/handlers/k8sHandler.ts
+++ b/k8s-plugin-deck/src/handlers/k8sHandler.ts
@@ -1,0 +1,25 @@
+import { IManagedDeliveryPlugin, IResourceKindConfig } from '@spinnaker/core';
+import { IManagedResourceSummary } from '@spinnaker/core/lib/domain';
+import { IconNames } from '@spinnaker/presentation';
+
+
+class k8sResourceHandler implements IResourceKindConfig {
+    kind = "k8s/resource"
+    iconName: IconNames = "spMenuK8s"
+    experimentalDisplayLink = this.displayLink()
+
+    public displayLink(): ((resource: IManagedResourceSummary) => string) {
+        return function (resource: IManagedResourceSummary) {
+            const baseUrl = `${window.location.protocol}//${window.location.host}`
+            // const path = `#/applications/${resource.moniker?.app}/loadBalancers`
+            // currently k8s plugin doesn't return moniker field
+            const path = `#/applications/moretest/loadBalancers`
+            const params = `?acct=${resource.locations.account}`
+            return `${path}${params}`
+        }
+    }
+}
+
+export class k8sManagedDeliveryPlugin implements IManagedDeliveryPlugin {
+    resources: IResourceKindConfig[] = [new k8sResourceHandler()]
+}

--- a/k8s-plugin-deck/src/index.ts
+++ b/k8s-plugin-deck/src/index.ts
@@ -1,0 +1,5 @@
+import { IDeckPlugin } from '@spinnaker/core';
+import {k8sManagedDeliveryPlugin} from "./handlers/k8sHandler"
+export const plugin: IDeckPlugin = {
+    managedDelivery: new k8sManagedDeliveryPlugin
+};

--- a/k8s-plugin-deck/tsconfig.json
+++ b/k8s-plugin-deck/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@spinnaker/pluginsdk/pluginconfig/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "build/dist",
+    "rootDir": "src"
+  }
+}


### PR DESCRIPTION
Adds initial support for UI.
Note that since the backend plugin does not return the moniker field, `${resource.moniker?.app}` will be `undefined`. This should resolve to correct application once the backend plugin returns the field. 

To test this:
1. Allow requests from localhost by adding the following to `gate.yml`. The last capture group should be your own url. 
```
cors:
  allowedOriginsPattern: ^(https?:\/\/(?:localhost|[0-9\.]+)(?::[1-9]\d*)?\/?)|(https:\/\/spinnaker.mccloman.people.aws.dev)
```
2. port-forward gate service
```
kubectl -n keel port-forward svc/deck 9001:443
```
3. Run:
```
cd k8s-plugin-deck
yarn && yarn build
```
4.  Run:
```
DEV_PROXY_HOST=http://localhost:9001 yarn develop
```
5. Navigate to localhost:9000
