### PR TITLE
first iteration on implementing HELM reseolver

### DIFF
--- a/k8s-plugin/k8s-plugin.gradle
+++ b/k8s-plugin/k8s-plugin.gradle
@@ -39,6 +39,7 @@ dependencies {
     compileOnly (group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.12.1')
 
     kapt(group: 'org.pf4j', name: 'pf4j', version: "${pf4jVersion}")
+    implementation("io.github.microutils:kotlin-logging:1.12.0")
 
     testImplementation (group: 'io.spinnaker.keel', name: 'keel-core', version: "${keelVersion}")
     testImplementation (group: 'io.spinnaker.keel', name: 'keel-api', version: "${keelVersion}")

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/K8sConfig.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/K8sConfig.kt
@@ -1,9 +1,11 @@
 package com.amazon.spinnaker.keel.k8s
 
+import com.amazon.spinnaker.keel.k8s.model.HelmResourceSpec
 import com.amazon.spinnaker.keel.k8s.model.K8sResourceSpec
 import com.netflix.spinnaker.keel.api.plugins.kind
 
-val K8S_RESOURCE_SPEC_V1 = kind <K8sResourceSpec>("k8s/resource@v1")
+val K8S_RESOURCE_SPEC_V1  = kind <K8sResourceSpec>("k8s/resource@v1")
+val HELM_RESOURCE_SPEC_V1 = kind <HelmResourceSpec>("k8s/helm@v1")
 
 const val K8S_PROVIDER = "kubernetes"
 const val SOURCE_TYPE = "text"

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/ManagedDeliveryK8sPlugin.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/ManagedDeliveryK8sPlugin.kt
@@ -4,6 +4,7 @@ import com.amazon.spinnaker.keel.k8s.resolver.DockerImageResolver
 import com.amazon.spinnaker.keel.k8s.resolver.HelmResourceHandler
 import com.amazon.spinnaker.keel.k8s.resolver.K8sResolver
 import com.amazon.spinnaker.keel.k8s.resolver.K8sResourceHandler
+import com.amazon.spinnaker.keel.k8s.service.CloudDriverK8sServiceSupplier
 import com.netflix.spinnaker.kork.plugins.api.spring.PrivilegedSpringPlugin
 import org.pf4j.PluginWrapper
 import org.springframework.beans.factory.support.BeanDefinitionRegistry

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/ManagedDeliveryK8sPlugin.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/ManagedDeliveryK8sPlugin.kt
@@ -1,6 +1,7 @@
 package com.amazon.spinnaker.keel.k8s
 
 import com.amazon.spinnaker.keel.k8s.resolver.DockerImageResolver
+import com.amazon.spinnaker.keel.k8s.resolver.HelmResourceHandler
 import com.amazon.spinnaker.keel.k8s.resolver.K8sResolver
 import com.amazon.spinnaker.keel.k8s.resolver.K8sResourceHandler
 import com.netflix.spinnaker.kork.plugins.api.spring.PrivilegedSpringPlugin
@@ -21,6 +22,7 @@ class ManagedDeliveryK8sPlugin(wrapper: PluginWrapper) : PrivilegedSpringPlugin(
         listOf(
                 beanDefinitionFor(CloudDriverK8sServiceSupplier::class.java),
                 beanDefinitionFor(K8sResourceHandler::class.java),
+                beanDefinitionFor(HelmResourceHandler::class.java),
                 beanDefinitionFor(K8sResolver::class.java),
                 beanDefinitionFor(DockerImageResolver::class.java)
         ).forEach {

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/GenericK8sLocatable.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/GenericK8sLocatable.kt
@@ -1,0 +1,22 @@
+package com.amazon.spinnaker.keel.k8s.model
+
+import com.amazon.spinnaker.keel.k8s.*
+import com.netflix.spinnaker.keel.api.Locatable
+import com.netflix.spinnaker.keel.api.SimpleLocations
+
+interface GenericK8sLocatable : Locatable<SimpleLocations> {
+    val metadata: Map<String, String>
+    val template: K8sObjectManifest
+
+    val namespace: String
+        get() = (template.metadata[NAMESPACE] ?: NAMESPACE_DEFAULT) as String
+
+    override val application: String
+        get() = metadata.getValue(APPLICATION).toString()
+
+    override val id: String
+        get() = "$namespace-${template.kind}-${template.metadata[NAME]}".toLowerCase()
+
+    override val displayName: String
+        get() = "$namespace-${template.kind}-${template.metadata[NAME]}".toLowerCase()
+}

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/GenericK8sLocatable.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/GenericK8sLocatable.kt
@@ -15,8 +15,8 @@ interface GenericK8sLocatable : Locatable<SimpleLocations> {
         get() = metadata.getValue(APPLICATION).toString()
 
     override val id: String
-        get() = "$namespace-${template.kind}-${template.metadata[NAME]}".toLowerCase()
+        get() = "${locations.account}-$namespace-${template.kind}-${template.metadata[NAME]}".toLowerCase()
 
     override val displayName: String
-        get() = "$namespace-${template.kind}-${template.metadata[NAME]}".toLowerCase()
+        get() = "${locations.account}-$namespace-${template.kind}-${template.metadata[NAME]}".toLowerCase()
 }

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/HelmResourceSpec.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/HelmResourceSpec.kt
@@ -1,0 +1,12 @@
+package com.amazon.spinnaker.keel.k8s.model
+
+import com.amazon.spinnaker.keel.k8s.*
+import com.netflix.spinnaker.keel.api.SimpleLocations
+import com.netflix.spinnaker.keel.docker.ReferenceProvider
+
+class HelmResourceSpec (
+    val chart: ReferenceProvider?,
+    override val metadata: Map<String, String>,
+    override val template: K8sObjectManifest,
+    override val locations: SimpleLocations,
+): GenericK8sLocatable

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/K8sResourceSpec.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/K8sResourceSpec.kt
@@ -9,21 +9,10 @@ import com.netflix.spinnaker.keel.docker.ReferenceProvider
 
 data class K8sResourceSpec(
     val container: ContainerProvider?,
-    val metadata: Map<String, String>,
-    var template: K8sObjectManifest,
+    override val metadata: Map<String, String>,
+    override val template: K8sObjectManifest,
     override val locations: SimpleLocations
-) : ArtifactReferenceProvider, ResourceSpec, Locatable<SimpleLocations> {
-
-    private val namespace: String = (template.metadata[NAMESPACE] ?: NAMESPACE_DEFAULT) as String
-
-    override val application: String
-        get() = metadata.getValue(APPLICATION).toString()
-
-    override val id: String
-        get() = "$namespace-${template.kind}-${template.metadata[NAME]}".toLowerCase()
-
-    override val displayName: String
-        get() = "$namespace-${template.kind}-${template.metadata[NAME]}".toLowerCase()
+) : ArtifactReferenceProvider, GenericK8sLocatable {
 
     override val artifactReference: String?
         get() = if (container != null) (container as ReferenceProvider).reference else null

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/GenericK8sResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/GenericK8sResourceHandler.kt
@@ -2,10 +2,7 @@ package com.amazon.spinnaker.keel.k8s.resolver
 
 import com.amazon.spinnaker.keel.k8s.*
 import com.amazon.spinnaker.keel.k8s.model.GenericK8sLocatable
-import com.amazon.spinnaker.keel.k8s.model.HelmResourceSpec
-import com.amazon.spinnaker.keel.k8s.model.K8sResourceSpec
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
+import com.amazon.spinnaker.keel.k8s.service.CloudDriverK8sService
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceDiff
 import com.netflix.spinnaker.keel.api.actuation.Task

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/GenericK8sResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/GenericK8sResourceHandler.kt
@@ -1,0 +1,109 @@
+package com.amazon.spinnaker.keel.k8s.resolver
+
+import com.amazon.spinnaker.keel.k8s.*
+import com.amazon.spinnaker.keel.k8s.model.GenericK8sLocatable
+import com.amazon.spinnaker.keel.k8s.model.HelmResourceSpec
+import com.amazon.spinnaker.keel.k8s.model.K8sResourceSpec
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.ResourceDiff
+import com.netflix.spinnaker.keel.api.actuation.Task
+import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
+import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
+import com.netflix.spinnaker.keel.api.plugins.Resolver
+import com.netflix.spinnaker.keel.api.plugins.SupportedKind
+import com.netflix.spinnaker.keel.api.support.EventPublisher
+import com.netflix.spinnaker.keel.model.Job
+import kotlinx.coroutines.coroutineScope
+import mu.KotlinLogging
+import retrofit2.HttpException
+
+abstract class GenericK8sResourceHandler <S: GenericK8sLocatable, R: K8sObjectManifest>(
+    open val cloudDriverK8sService: CloudDriverK8sService,
+    open val taskLauncher: TaskLauncher,
+    override val eventPublisher: EventPublisher,
+    open val resolvers: List<Resolver<*>>
+    ): ResolvableResourceHandler<S, R>(resolvers) {
+
+    val logger = KotlinLogging.logger {}
+
+    override val supportedKind: SupportedKind<S>
+        get() = TODO("Not yet implemented")
+
+    override suspend fun toResolvedType(resource: Resource<S>): R =
+        with(resource.spec) {
+            return (this.template as R)
+        }
+
+    open suspend fun CloudDriverK8sService.getK8sResource(
+        r: Resource<S>,
+    ): R? =
+        coroutineScope {
+            try {
+                getK8sResource(
+                    r.serviceAccount,
+                    r.spec.locations.account,
+                    r.spec.template.namespace(),
+                    r.spec.template.kindQualifiedName()
+                ).toResourceModel()
+            } catch (e: HttpException) {
+                if (e.code() == 404) {
+                    logger.info("resource ${r.id} not found")
+                    null
+                } else {
+                    throw e
+                }
+            }
+        }
+
+    abstract suspend fun getK8sResource(r: Resource<S>) : R?
+
+    private fun K8sResourceModel.toResourceModel() : R =
+        K8sObjectManifest(
+            apiVersion = manifest.apiVersion,
+            kind = manifest.kind,
+            metadata = manifest.metadata,
+            spec = manifest.spec
+        ) as R
+
+    override suspend fun upsert(
+        resource: Resource<S>,
+        diff: ResourceDiff<R>
+    ): List<Task> {
+
+        if (!diff.hasChanges()) {
+            return emptyList()
+        }
+
+        val spec = (diff.desired)
+        val account = resource.spec.locations.account
+
+        return listOf(
+            taskLauncher.submitJob(
+                resource = resource,
+                description = "applying k8s resource: ${spec.name()} ",
+                correlationId = spec.name(),
+                job = spec.job((resource.metadata["application"] as String), account)
+            )
+        )
+    }
+
+    fun R.job(app: String, account: String): Job =
+        Job(
+            "deployManifest",
+            mapOf(
+                "moniker" to mapOf(
+                    "app" to app,
+                    "location" to namespace()
+                ),
+                "cloudProvider" to K8S_PROVIDER,
+                "credentials" to account,
+                "manifests" to listOf(this),
+                "optionalArtifacts" to listOf<Map<Any, Any>>(),
+                "requiredArtifacts" to listOf<Map<String, Any?>>(),
+                "source" to SOURCE_TYPE,
+                "enableTraffic" to true.toString()
+            )
+        )
+}

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/HelmResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/HelmResourceHandler.kt
@@ -1,0 +1,43 @@
+package com.amazon.spinnaker.keel.k8s.resolver
+
+import com.amazon.spinnaker.keel.k8s.*
+import com.amazon.spinnaker.keel.k8s.model.GenericK8sLocatable
+import com.amazon.spinnaker.keel.k8s.model.HelmResourceSpec
+import com.amazon.spinnaker.keel.k8s.model.K8sResourceSpec
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.ResourceDiff
+import com.netflix.spinnaker.keel.api.actuation.Task
+import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
+import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
+import com.netflix.spinnaker.keel.api.plugins.Resolver
+import com.netflix.spinnaker.keel.api.plugins.SupportedKind
+import com.netflix.spinnaker.keel.api.support.EventPublisher
+import kotlinx.coroutines.coroutineScope
+import retrofit2.HttpException
+
+class HelmResourceHandler(
+    override val cloudDriverK8sService: CloudDriverK8sService,
+    override val taskLauncher: TaskLauncher,
+    override val eventPublisher: EventPublisher,
+    override val resolvers: List<Resolver<*>>
+) : GenericK8sResourceHandler<HelmResourceSpec, K8sObjectManifest>(
+    cloudDriverK8sService, taskLauncher, eventPublisher, resolvers
+) {
+    override val supportedKind = HELM_RESOURCE_SPEC_V1
+
+    override suspend fun current(resource: Resource<HelmResourceSpec>): K8sObjectManifest? {
+        val clusterResource = cloudDriverK8sService.getK8sResource(resource) ?: return null
+        val mapper = jacksonObjectMapper()
+        val lastAppliedConfig = (clusterResource.metadata[ANNOTATIONS] as Map<String, String>)[K8S_LAST_APPLIED_CONFIG] as String
+        return mapper.readValue<K8sObjectManifest>(lastAppliedConfig)
+    }
+
+    override suspend fun getK8sResource(r: Resource<HelmResourceSpec>): K8sObjectManifest? =
+        coroutineScope {
+            // defer to GenericK8sResourceHandler to get the resource
+            // from the k8s cluster
+            cloudDriverK8sService.getK8sResource(r) ?: null
+        }
+}

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/HelmResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/HelmResourceHandler.kt
@@ -1,21 +1,15 @@
 package com.amazon.spinnaker.keel.k8s.resolver
 
 import com.amazon.spinnaker.keel.k8s.*
-import com.amazon.spinnaker.keel.k8s.model.GenericK8sLocatable
 import com.amazon.spinnaker.keel.k8s.model.HelmResourceSpec
-import com.amazon.spinnaker.keel.k8s.model.K8sResourceSpec
+import com.amazon.spinnaker.keel.k8s.service.CloudDriverK8sService
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.ResourceDiff
-import com.netflix.spinnaker.keel.api.actuation.Task
 import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
-import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
-import com.netflix.spinnaker.keel.api.plugins.SupportedKind
 import com.netflix.spinnaker.keel.api.support.EventPublisher
 import kotlinx.coroutines.coroutineScope
-import retrofit2.HttpException
 
 class HelmResourceHandler(
     override val cloudDriverK8sService: CloudDriverK8sService,

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/K8sResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/K8sResourceHandler.kt
@@ -4,6 +4,7 @@ import com.amazon.spinnaker.keel.k8s.*
 import com.amazon.spinnaker.keel.k8s.model.GenericK8sLocatable
 import com.amazon.spinnaker.keel.k8s.model.HelmResourceSpec
 import com.amazon.spinnaker.keel.k8s.model.K8sResourceSpec
+import com.amazon.spinnaker.keel.k8s.service.CloudDriverK8sService
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.keel.api.Resource

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/service/CloudDriverK8sService.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/service/CloudDriverK8sService.kt
@@ -1,5 +1,6 @@
-package com.amazon.spinnaker.keel.k8s
+package com.amazon.spinnaker.keel.k8s.service
 
+import com.amazon.spinnaker.keel.k8s.K8sResourceModel
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.config.DefaultServiceEndpoint
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/K8sResourceHandlerTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/K8sResourceHandlerTest.kt
@@ -4,6 +4,7 @@ import com.amazon.spinnaker.keel.k8s.*
 import com.amazon.spinnaker.keel.k8s.model.K8sResourceSpec
 import com.amazon.spinnaker.keel.k8s.resolver.K8sResolver
 import com.amazon.spinnaker.keel.k8s.resolver.K8sResourceHandler
+import com.amazon.spinnaker.keel.k8s.service.CloudDriverK8sService
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.events.ArtifactVersionDeploying

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/K8sResourceSpecTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/K8sResourceSpecTest.kt
@@ -58,6 +58,14 @@ internal object K8sResourceSpecTests : JUnit5Minutests {
                     mapper.readValue(yaml)
                 }
 
+                test("name matches the specification") {
+                    expectThat(this).get { id }.isEqualTo("my-k8s-west-account-default-deployment-hello-kubernetes")
+                }
+
+                test("name matches the specification") {
+                    expectThat(this).get { displayName }.isEqualTo("my-k8s-west-account-default-deployment-hello-kubernetes")
+                }
+
                 test("can be deserialized to a K8s object") {
                     expectThat(this)
                         .get { template.spec["replicas"] }.isEqualTo(2)


### PR DESCRIPTION
- introduces GenericK8sLocatable and GenericK8sResourceHandler as abstracts to be used by lower level handlers
- adds HelmResourceSpec with an optional chart reference
- adds HelmResourceHandler to parse k8s/helm@v1 resource types
- relies and the existance of flux2 helm controller
- adds tests for HelmResourceSpec

This deliberately skips adding tests for `HelmResourceHandler` as most of the testing is already done in `K8sResourceHandler` and there isn't anything specific to HELM so far. As we add more functionality, we should add tests for the HELM handler as well.