### PR TITLE
initial implementation of Credentials handler

### DIFF
--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/K8sConfig.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/K8sConfig.kt
@@ -1,11 +1,13 @@
 package com.amazon.spinnaker.keel.k8s
 
+import com.amazon.spinnaker.keel.k8s.model.CredentialsResourceSpec
 import com.amazon.spinnaker.keel.k8s.model.HelmResourceSpec
 import com.amazon.spinnaker.keel.k8s.model.K8sResourceSpec
 import com.netflix.spinnaker.keel.api.plugins.kind
 
 val K8S_RESOURCE_SPEC_V1  = kind <K8sResourceSpec>("k8s/resource@v1")
 val HELM_RESOURCE_SPEC_V1 = kind <HelmResourceSpec>("k8s/helm@v1")
+val CREDENTIALS_RESOURCE_SPEC_V1 = kind <CredentialsResourceSpec>("k8s/credentials@v1")
 
 const val K8S_PROVIDER = "kubernetes"
 const val SOURCE_TYPE = "text"

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/K8sConfig.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/K8sConfig.kt
@@ -7,7 +7,7 @@ import com.netflix.spinnaker.keel.api.plugins.kind
 
 val K8S_RESOURCE_SPEC_V1  = kind <K8sResourceSpec>("k8s/resource@v1")
 val HELM_RESOURCE_SPEC_V1 = kind <HelmResourceSpec>("k8s/helm@v1")
-val CREDENTIALS_RESOURCE_SPEC_V1 = kind <CredentialsResourceSpec>("k8s/credentials@v1")
+val CREDENTIALS_RESOURCE_SPEC_V1 = kind <CredentialsResourceSpec>("k8s/credential@v1")
 
 const val K8S_PROVIDER = "kubernetes"
 const val SOURCE_TYPE = "text"

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/ManagedDeliveryK8sPlugin.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/ManagedDeliveryK8sPlugin.kt
@@ -1,9 +1,6 @@
 package com.amazon.spinnaker.keel.k8s
 
-import com.amazon.spinnaker.keel.k8s.resolver.DockerImageResolver
-import com.amazon.spinnaker.keel.k8s.resolver.HelmResourceHandler
-import com.amazon.spinnaker.keel.k8s.resolver.K8sResolver
-import com.amazon.spinnaker.keel.k8s.resolver.K8sResourceHandler
+import com.amazon.spinnaker.keel.k8s.resolver.*
 import com.amazon.spinnaker.keel.k8s.service.CloudDriverK8sServiceSupplier
 import com.netflix.spinnaker.kork.plugins.api.spring.PrivilegedSpringPlugin
 import org.pf4j.PluginWrapper
@@ -25,6 +22,7 @@ class ManagedDeliveryK8sPlugin(wrapper: PluginWrapper) : PrivilegedSpringPlugin(
                 beanDefinitionFor(K8sResourceHandler::class.java),
                 beanDefinitionFor(HelmResourceHandler::class.java),
                 beanDefinitionFor(K8sResolver::class.java),
+                beanDefinitionFor(CredentialsResourceHandler::class.java),
                 beanDefinitionFor(DockerImageResolver::class.java)
         ).forEach {
             registerBean(it, registry)

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/ManagedDeliveryK8sPlugin.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/ManagedDeliveryK8sPlugin.kt
@@ -1,6 +1,9 @@
 package com.amazon.spinnaker.keel.k8s
 
-import com.amazon.spinnaker.keel.k8s.resolver.*
+import com.amazon.spinnaker.keel.k8s.resolver.CredentialsResourceHandler
+import com.amazon.spinnaker.keel.k8s.resolver.DockerImageResolver
+import com.amazon.spinnaker.keel.k8s.resolver.K8sResolver
+import com.amazon.spinnaker.keel.k8s.resolver.K8sResourceHandler
 import com.amazon.spinnaker.keel.k8s.service.CloudDriverK8sServiceSupplier
 import com.netflix.spinnaker.kork.plugins.api.spring.PrivilegedSpringPlugin
 import org.pf4j.PluginWrapper
@@ -20,10 +23,9 @@ class ManagedDeliveryK8sPlugin(wrapper: PluginWrapper) : PrivilegedSpringPlugin(
         listOf(
                 beanDefinitionFor(CloudDriverK8sServiceSupplier::class.java),
                 beanDefinitionFor(K8sResourceHandler::class.java),
-                beanDefinitionFor(HelmResourceHandler::class.java),
                 beanDefinitionFor(K8sResolver::class.java),
-                beanDefinitionFor(CredentialsResourceHandler::class.java),
-                beanDefinitionFor(DockerImageResolver::class.java)
+                beanDefinitionFor(DockerImageResolver::class.java),
+                beanDefinitionFor(CredentialsResourceHandler::class.java)
         ).forEach {
             registerBean(it, registry)
         }

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/exception/K8sPluginExceptions.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/exception/K8sPluginExceptions.kt
@@ -15,3 +15,5 @@ class DuplicateReference(reference: String) :
 class NotLinked(reference: String) :
     IntegrationException("contianer with reference $reference is not linked in resource. " +
             "resource image should have the same value as the container image for references to be linked")
+class CouldNotRetrieveCredentials(accountName: String, e :Throwable? = null) :
+    ResourceCurrentlyUnresolvable("could not retrieve account named $accountName in clouddriver", e)

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/CredentialsResourceSpec.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/CredentialsResourceSpec.kt
@@ -8,6 +8,5 @@ data class CredentialsResourceSpec(
     override val metadata: Map<String, String>,
     override val template: K8sObjectManifest?,
     override val namespace: String,
-    val name: String,
     val account: String
 ) : GenericK8sLocatable

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/CredentialsResourceSpec.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/CredentialsResourceSpec.kt
@@ -6,7 +6,5 @@ import com.netflix.spinnaker.keel.api.SimpleLocations
 data class CredentialsResourceSpec(
     override val locations: SimpleLocations,
     override val metadata: Map<String, String>,
-    override val template: K8sObjectManifest?,
-    override val namespace: String,
-    val account: String
+    override val template: K8sObjectManifest,
 ) : GenericK8sLocatable

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/CredentialsResourceSpec.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/CredentialsResourceSpec.kt
@@ -1,0 +1,13 @@
+package com.amazon.spinnaker.keel.k8s.model
+
+import com.amazon.spinnaker.keel.k8s.K8sObjectManifest
+import com.netflix.spinnaker.keel.api.SimpleLocations
+
+data class CredentialsResourceSpec(
+    override val locations: SimpleLocations,
+    override val metadata: Map<String, String>,
+    override val template: K8sObjectManifest?,
+    override val namespace: String,
+    val name: String,
+    val account: String
+) : GenericK8sLocatable

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/GenericK8sLocatable.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/GenericK8sLocatable.kt
@@ -6,17 +6,16 @@ import com.netflix.spinnaker.keel.api.SimpleLocations
 
 interface GenericK8sLocatable : Locatable<SimpleLocations> {
     val metadata: Map<String, String>
-    val template: K8sObjectManifest
-
+    val template: K8sObjectManifest?
     val namespace: String
-        get() = (template.metadata[NAMESPACE] ?: NAMESPACE_DEFAULT) as String
+        get() = (template?.metadata?.get(NAMESPACE) ?: NAMESPACE_DEFAULT) as String
 
     override val application: String
         get() = metadata.getValue(APPLICATION).toString()
 
     override val id: String
-        get() = "${locations.account}-$namespace-${template.kind}-${template.metadata[NAME]}".toLowerCase()
+        get() = "${locations.account}-$namespace-${template?.kind}-${template?.metadata?.get(NAME)}".toLowerCase()
 
     override val displayName: String
-        get() = "${locations.account}-$namespace-${template.kind}-${template.metadata[NAME]}".toLowerCase()
+        get() = "${locations.account}-$namespace-${template?.kind}-${template?.metadata?.get(NAME)}".toLowerCase()
 }

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/GitRepoAccountDetails.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/GitRepoAccountDetails.kt
@@ -1,0 +1,15 @@
+package com.amazon.spinnaker.keel.k8s.model
+
+data class GitRepoAccountDetails(
+    val name: String = "",
+    val token: String = "",
+    val username: String = "",
+    val password: String = "",
+    val sshPrivateKeyFilePath: String = "",
+    val sshPrivateKeyPassphrase: String = "",
+    val sshPrivateKeyPassphraseCmd: String = "",
+    val sshKnownHostsFilePath: String = "",
+    val sshTrustUnknownHosts: Boolean = false,
+    val repos: List<String> = emptyList(),
+    val sshPrivateKey: String = ""
+)

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/K8sResourceModel.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/K8sResourceModel.kt
@@ -17,7 +17,14 @@ data class K8sResourceModel(
 )
 
 typealias K8sSpec = MutableMap<String, Any?>
-typealias K8sData = MutableMap<String, Any>
+
+data class K8sData(
+    val account: String? = null,
+    val username: String? = null,
+    val password: String? = null,
+    val identity: String? = null
+)
+
 
 data class K8sObjectManifest(
     val apiVersion: String,

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/K8sResourceModel.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/K8sResourceModel.kt
@@ -17,13 +17,15 @@ data class K8sResourceModel(
 )
 
 typealias K8sSpec = MutableMap<String, Any?>
+typealias K8sData = MutableMap<String, Any>
 
 data class K8sObjectManifest(
     val apiVersion: String,
     val kind: String,
     @get:ExcludedFromDiff
     val metadata: Map<String, Any?>,
-    val spec: K8sSpec
+    val spec: K8sSpec?,
+    val data: K8sData? = null
 ) {
     fun namespace(): String = (metadata[NAMESPACE] ?: NAMESPACE_DEFAULT) as String
     fun name(): String = metadata[NAME] as String

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/CredentialsResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/CredentialsResourceHandler.kt
@@ -1,0 +1,99 @@
+package com.amazon.spinnaker.keel.k8s.resolver
+
+import com.amazon.spinnaker.keel.k8s.CREDENTIALS_RESOURCE_SPEC_V1
+import com.amazon.spinnaker.keel.k8s.K8sObjectManifest
+import com.amazon.spinnaker.keel.k8s.model.CredentialsResourceSpec
+import com.amazon.spinnaker.keel.k8s.service.CloudDriverK8sService
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
+import com.netflix.spinnaker.keel.api.plugins.Resolver
+import com.netflix.spinnaker.keel.api.support.EventPublisher
+import com.netflix.spinnaker.keel.orca.OrcaService
+import retrofit2.HttpException
+import java.util.*
+
+class CredentialsResourceHandler(
+    cloudDriverK8sService: CloudDriverK8sService, taskLauncher: TaskLauncher, eventPublisher: EventPublisher,
+    orcaService: OrcaService, resolvers: List<Resolver<*>>
+) : GenericK8sResourceHandler<CredentialsResourceSpec, K8sObjectManifest>(
+    cloudDriverK8sService, taskLauncher,
+    eventPublisher, orcaService, resolvers
+) {
+    override val supportedKind = CREDENTIALS_RESOURCE_SPEC_V1
+    private val encoder: Base64.Encoder = Base64.getMimeEncoder()
+
+    public override suspend fun toResolvedType(resource: Resource<CredentialsResourceSpec>): K8sObjectManifest {
+        val cred = cloudDriverK8sService.getCredentialsDetails(resource.serviceAccount, resource.spec.account)
+        val data: MutableMap<String, String> = mutableMapOf()
+        // Priority: token > password > ssh key
+        when {
+            cred.token.isNotBlank() -> {
+                log.debug("populating token with username in manifest")
+                data.putAll(
+                    mapOf(
+                        "username" to encoder.encodeToString(cred.token.toByteArray()),
+                        "password" to ""
+                    )
+                )
+            }
+            cred.username.isNotBlank() -> {
+                log.debug("populating username and password in manifest")
+                data.putAll(
+                    mapOf(
+                        "username" to encoder.encodeToString(cred.username.toByteArray()),
+                        "password" to encoder.encodeToString(cred.password.toByteArray())
+                    )
+                )
+            }
+            cred.sshPrivateKey.isNotBlank() -> {
+                log.debug("populating private key in manifest")
+                data.putAll(mapOf("identity" to encoder.encodeToString(cred.sshPrivateKey.toByteArray())))
+            }
+        }
+        // setting strategy.spinnaker.io/versioned is needed to avoid creating secrets with versioned names e.g. testing1-v000
+        return K8sObjectManifest(
+            "v1",
+            "Secret",
+            mapOf(
+                "namespace" to resource.spec.namespace,
+                "name" to resource.spec.name,
+                "annotations" to mapOf("strategy.spinnaker.io/versioned" to "false")
+            ),
+            null,
+            data as MutableMap<String, Any>?
+        )
+    }
+
+    override suspend fun current(resource: Resource<CredentialsResourceSpec>): K8sObjectManifest? {
+        log.debug("resource received: $resource spec: ${resource.spec}")
+        try {
+            val res = cloudDriverK8sService.getK8sResource(
+                resource.serviceAccount,
+                resource.spec.locations.account,
+                resource.spec.namespace,
+                "secret ${resource.spec.name}"
+            )
+            log.debug("response from clouddriver: $res manifest: ${res.manifest}")
+            return res.manifest
+        } catch (e: HttpException) {
+            if (e.code() == 404) {
+                logger.info("resource ${resource.id} not found")
+                return null
+            } else {
+                throw e
+            }
+        }
+    }
+
+    override suspend fun getK8sResource(r: Resource<CredentialsResourceSpec>): K8sObjectManifest? {
+        return cloudDriverK8sService.getK8sResource(r)
+    }
+
+    override suspend fun actuationInProgress(resource: Resource<CredentialsResourceSpec>): Boolean =
+        resource.spec.name.let {
+            log.debug(resource.toString())
+            val a = orcaService.getCorrelatedExecutions(it)
+            log.debug("actuation in progress? ${a.isNotEmpty()}: $a")
+            a.isNotEmpty()
+        }
+}

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/CredentialsResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/CredentialsResourceHandler.kt
@@ -56,7 +56,7 @@ class CredentialsResourceHandler(
             "Secret",
             mapOf(
                 "namespace" to resource.spec.namespace,
-                "name" to resource.spec.name,
+                "name" to resource.spec.account,
                 "annotations" to mapOf("strategy.spinnaker.io/versioned" to "false")
             ),
             null,
@@ -71,7 +71,7 @@ class CredentialsResourceHandler(
                 resource.serviceAccount,
                 resource.spec.locations.account,
                 resource.spec.namespace,
-                "secret ${resource.spec.name}"
+                "secret ${resource.spec.account}"
             )
             log.debug("response from clouddriver: $res manifest: ${res.manifest}")
             return res.manifest
@@ -90,7 +90,7 @@ class CredentialsResourceHandler(
     }
 
     override suspend fun actuationInProgress(resource: Resource<CredentialsResourceSpec>): Boolean =
-        resource.spec.name.let {
+        resource.spec.account.let {
             log.debug(resource.toString())
             val a = orcaService.getCorrelatedExecutions(it)
             log.debug("actuation in progress? ${a.isNotEmpty()}: $a")

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/DockerImageResolver.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/DockerImageResolver.kt
@@ -38,10 +38,10 @@ class DockerImageResolver(
             artifact: DockerArtifact,
             tag: String
     ): Resource<K8sResourceSpec> {
-        val resourceTemplate = (resource.spec.template.spec[TEMPLATE] as MutableMap<String, Any>)
+        val resourceTemplate = (resource.spec.template.spec?.get(TEMPLATE) as MutableMap<String, Any>)
         val updatedMap = setValue(resourceTemplate, IMAGE, artifact.reference,
             "${artifact.organization}/${artifact.image}:${tag}")
-        resource.spec.template.spec[TEMPLATE] = updatedMap
+        resource.spec.template.spec!![TEMPLATE] = updatedMap
         return resource
     }
 

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/GenericK8sResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/GenericK8sResourceHandler.kt
@@ -81,9 +81,7 @@ abstract class GenericK8sResourceHandler <S: GenericK8sLocatable, R: K8sObjectMa
 
         val spec = (diff.desired)
         val account = resource.spec.locations.account
-        log.info("upserting....")
-        log.info(spec.toString())
-        log.info(spec.metadata.toString())
+        log.debug("upserting. spec: $spec")
         return listOf(
             taskLauncher.submitJob(
                 resource = resource,
@@ -93,12 +91,6 @@ abstract class GenericK8sResourceHandler <S: GenericK8sLocatable, R: K8sObjectMa
             )
         )
     }
-
-    override suspend fun actuationInProgress(resource: Resource<S>): Boolean =
-        resource
-            .spec.template?.let {
-                orcaService.getCorrelatedExecutions(it.name()).isNotEmpty()
-            }  ?: false
 
     fun R.job(app: String, account: String): Job =
         Job(

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/GenericK8sResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/GenericK8sResourceHandler.kt
@@ -1,6 +1,7 @@
 package com.amazon.spinnaker.keel.k8s.resolver
 
 import com.amazon.spinnaker.keel.k8s.*
+import com.amazon.spinnaker.keel.k8s.model.CredentialsResourceSpec
 import com.amazon.spinnaker.keel.k8s.model.GenericK8sLocatable
 import com.amazon.spinnaker.keel.k8s.service.CloudDriverK8sService
 import com.netflix.spinnaker.keel.api.Resource
@@ -12,6 +13,7 @@ import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.plugins.SupportedKind
 import com.netflix.spinnaker.keel.api.support.EventPublisher
 import com.netflix.spinnaker.keel.model.Job
+import com.netflix.spinnaker.keel.orca.OrcaService
 import kotlinx.coroutines.coroutineScope
 import mu.KotlinLogging
 import retrofit2.HttpException
@@ -20,6 +22,7 @@ abstract class GenericK8sResourceHandler <S: GenericK8sLocatable, R: K8sObjectMa
     open val cloudDriverK8sService: CloudDriverK8sService,
     open val taskLauncher: TaskLauncher,
     override val eventPublisher: EventPublisher,
+    val orcaService: OrcaService,
     open val resolvers: List<Resolver<*>>
     ): ResolvableResourceHandler<S, R>(resolvers) {
 
@@ -38,12 +41,14 @@ abstract class GenericK8sResourceHandler <S: GenericK8sLocatable, R: K8sObjectMa
     ): R? =
         coroutineScope {
             try {
-                getK8sResource(
-                    r.serviceAccount,
-                    r.spec.locations.account,
-                    r.spec.template.namespace(),
-                    r.spec.template.kindQualifiedName()
-                ).toResourceModel()
+                r.spec.template?.let {
+                    getK8sResource(
+                        r.serviceAccount,
+                        r.spec.locations.account,
+                        it.namespace(),
+                        r.spec.template!!.kindQualifiedName()
+                    ).toResourceModel()
+                }
             } catch (e: HttpException) {
                 if (e.code() == 404) {
                     logger.info("resource ${r.id} not found")
@@ -61,7 +66,8 @@ abstract class GenericK8sResourceHandler <S: GenericK8sLocatable, R: K8sObjectMa
             apiVersion = manifest.apiVersion,
             kind = manifest.kind,
             metadata = manifest.metadata,
-            spec = manifest.spec
+            spec = manifest.spec,
+            data = manifest.data
         ) as R
 
     override suspend fun upsert(
@@ -75,7 +81,9 @@ abstract class GenericK8sResourceHandler <S: GenericK8sLocatable, R: K8sObjectMa
 
         val spec = (diff.desired)
         val account = resource.spec.locations.account
-
+        log.info("upserting....")
+        log.info(spec.toString())
+        log.info(spec.metadata.toString())
         return listOf(
             taskLauncher.submitJob(
                 resource = resource,
@@ -85,6 +93,12 @@ abstract class GenericK8sResourceHandler <S: GenericK8sLocatable, R: K8sObjectMa
             )
         )
     }
+
+    override suspend fun actuationInProgress(resource: Resource<S>): Boolean =
+        resource
+            .spec.template?.let {
+                orcaService.getCorrelatedExecutions(it.name()).isNotEmpty()
+            }  ?: false
 
     fun R.job(app: String, account: String): Job =
         Job(

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/HelmResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/HelmResourceHandler.kt
@@ -36,4 +36,10 @@ class HelmResourceHandler(
             // from the k8s cluster
             cloudDriverK8sService.getK8sResource(r) ?: null
         }
+
+    override suspend fun actuationInProgress(resource: Resource<HelmResourceSpec>): Boolean =
+        resource
+            .spec.template.let {
+                orcaService.getCorrelatedExecutions(it.name()).isNotEmpty()
+            }
 }

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/HelmResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/HelmResourceHandler.kt
@@ -9,15 +9,17 @@ import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.support.EventPublisher
+import com.netflix.spinnaker.keel.orca.OrcaService
 import kotlinx.coroutines.coroutineScope
 
 class HelmResourceHandler(
     override val cloudDriverK8sService: CloudDriverK8sService,
     override val taskLauncher: TaskLauncher,
     override val eventPublisher: EventPublisher,
+    orcaService: OrcaService,
     override val resolvers: List<Resolver<*>>
 ) : GenericK8sResourceHandler<HelmResourceSpec, K8sObjectManifest>(
-    cloudDriverK8sService, taskLauncher, eventPublisher, resolvers
+    cloudDriverK8sService, taskLauncher, eventPublisher, orcaService, resolvers
 ) {
     override val supportedKind = HELM_RESOURCE_SPEC_V1
 

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/K8sResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/K8sResourceHandler.kt
@@ -15,6 +15,7 @@ import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.support.EventPublisher
 import com.netflix.spinnaker.keel.model.Job
+import com.netflix.spinnaker.keel.orca.OrcaService
 import kotlinx.coroutines.coroutineScope
 import retrofit2.HttpException
 import kotlin.collections.ArrayList
@@ -23,9 +24,10 @@ class K8sResourceHandler (
     override val cloudDriverK8sService: CloudDriverK8sService,
     override val taskLauncher: TaskLauncher,
     override val eventPublisher: EventPublisher,
+    orcaService: OrcaService,
     override val resolvers: List<Resolver<*>>
 ) : GenericK8sResourceHandler<K8sResourceSpec, K8sObjectManifest>(
-    cloudDriverK8sService, taskLauncher, eventPublisher, resolvers
+    cloudDriverK8sService, taskLauncher, eventPublisher, orcaService, resolvers
 ) {
 
     override val supportedKind = K8S_RESOURCE_SPEC_V1
@@ -48,7 +50,7 @@ class K8sResourceHandler (
                 // notify change to the k8s vanilla image artifact based
                 // on retrieved data
                 manifest?.let {
-                    val imageString = find(it.spec, IMAGE) as String?
+                    val imageString = it.spec?.let { it1 -> find(it1, IMAGE) } as String?
                     imageString?.let {
                         log.info("Deployed artifact $it")
                         notifyArtifactDeployed(r as Resource<K8sResourceSpec>, getTag(it))

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/K8sResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/K8sResourceHandler.kt
@@ -97,4 +97,11 @@ class K8sResourceHandler (
         }
         return null
     }
+
+    override suspend fun actuationInProgress(resource: Resource<K8sResourceSpec>): Boolean =
+        resource
+            .spec.template.let {
+                orcaService.getCorrelatedExecutions(it.name()).isNotEmpty()
+            }
+
 }

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/service/CloudDriverK8sService.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/service/CloudDriverK8sService.kt
@@ -1,6 +1,7 @@
 package com.amazon.spinnaker.keel.k8s.service
 
 import com.amazon.spinnaker.keel.k8s.K8sResourceModel
+import com.amazon.spinnaker.keel.k8s.model.GitRepoAccountDetails
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.config.DefaultServiceEndpoint
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider
@@ -19,6 +20,12 @@ interface CloudDriverK8sService {
         @Path("namespace") namespace: String,
         @Path("resource") resource: String
     ): K8sResourceModel
+
+    @GET("/credentialsDetails/gitRepo/{account}")
+    suspend fun getCredentialsDetails(
+        @Header("X-SPINNAKER-USER") acc: String,
+        @Path("account") account: String
+    ): GitRepoAccountDetails
 }
 
 class CloudDriverK8sServiceSupplier(
@@ -38,6 +45,10 @@ class CloudDriverK8sServiceSupplier(
 
     override suspend fun getK8sResource(acc: String, account: String, namespace: String, resource: String): K8sResourceModel {
         return client.getK8sResource(acc, account, namespace, resource)
+    }
+
+    override suspend fun getCredentialsDetails(acc: String, account: String): GitRepoAccountDetails {
+        return client.getCredentialsDetails(acc, account)
     }
 }
 

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/CredentialsHandlerTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/CredentialsHandlerTest.kt
@@ -56,7 +56,6 @@ class CredentialsHandlerTest : JUnit5Minutests {
         |  regions: []
         |metadata:
         |  application: test
-        |name: test
         |namespace: test-ns
         |account: test-git-repo
     """.trimMargin()
@@ -99,7 +98,7 @@ class CredentialsHandlerTest : JUnit5Minutests {
                     val result = toResolvedType(resource)
                     val annotations = result.metadata["annotations"] as Map<String, String>
                     expectThat(result.metadata) {
-                        hasEntry("name", "test")
+                        hasEntry("name", "test-git-repo")
                         hasEntry("namespace", "test-ns")
                     }
                     expectThat(annotations["strategy.spinnaker.io/versioned"]).isEqualTo("false")
@@ -163,7 +162,7 @@ class CredentialsHandlerTest : JUnit5Minutests {
                     apiVersion = "v1",
                     kind = "Secret",
                     metadata = mapOf(
-                        "name" to "test",
+                        "name" to "test-git-repo",
                     ),
                     spec = mutableMapOf<String, Any>() as K8sSpec
                 )
@@ -173,7 +172,7 @@ class CredentialsHandlerTest : JUnit5Minutests {
                         any(),
                         "my-k8s-west-account",
                         "test-ns",
-                        "secret test"
+                        "secret test-git-repo"
                     )
                 } returnsMany listOf(
                     K8sResourceModel("", null, null, null, manifest, null, null, null, null, null),
@@ -183,7 +182,7 @@ class CredentialsHandlerTest : JUnit5Minutests {
             test("should return manifest") {
                 runBlocking {
                     val result = current(resource)
-                    expectThat(result!!.metadata["name"]).isEqualTo("test")
+                    expectThat(result!!.metadata["name"]).isEqualTo("test-git-repo")
                 }
             }
         }
@@ -198,7 +197,7 @@ class CredentialsHandlerTest : JUnit5Minutests {
                         any(),
                         "my-k8s-west-account",
                         "test-ns",
-                        "secret test"
+                        "secret test-git-repo"
                     )
                 } throws HttpException(notFound)
             }
@@ -213,7 +212,7 @@ class CredentialsHandlerTest : JUnit5Minutests {
 
         context("actuation is in progress") {
             before {
-                coEvery { orcaService.getCorrelatedExecutions(resource.spec.name) } returnsMany listOf(
+                coEvery { orcaService.getCorrelatedExecutions(resource.spec.account) } returnsMany listOf(
                     listOf("executionId1"), emptyList()
                 )
             }

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/CredentialsHandlerTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/CredentialsHandlerTest.kt
@@ -1,0 +1,231 @@
+package com.amazon.spinnaker.keel.tests
+
+import com.amazon.spinnaker.keel.k8s.CREDENTIALS_RESOURCE_SPEC_V1
+import com.amazon.spinnaker.keel.k8s.K8sObjectManifest
+import com.amazon.spinnaker.keel.k8s.K8sResourceModel
+import com.amazon.spinnaker.keel.k8s.K8sSpec
+import com.amazon.spinnaker.keel.k8s.model.CredentialsResourceSpec
+import com.amazon.spinnaker.keel.k8s.model.GitRepoAccountDetails
+import com.amazon.spinnaker.keel.k8s.resolver.CredentialsResourceHandler
+import com.amazon.spinnaker.keel.k8s.resolver.K8sResolver
+import com.amazon.spinnaker.keel.k8s.service.CloudDriverK8sService
+import com.netflix.spinnaker.keel.api.plugins.Resolver
+import com.netflix.spinnaker.keel.api.support.EventPublisher
+import com.netflix.spinnaker.keel.orca.OrcaService
+import com.netflix.spinnaker.keel.orca.OrcaTaskLauncher
+import com.netflix.spinnaker.keel.persistence.KeelRepository
+import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
+import com.netflix.spinnaker.keel.test.resource
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import okhttp3.ResponseBody
+import org.springframework.core.env.Environment
+import org.springframework.http.HttpStatus
+import retrofit2.HttpException
+import retrofit2.Response
+import strikt.api.expectThat
+import strikt.assertions.*
+import java.util.*
+
+@Suppress("UNCHECKED_CAST")
+class CredentialsHandlerTest : JUnit5Minutests {
+    private val cloudDriverK8sService = mockk<CloudDriverK8sService>()
+    private val orcaService = mockk<OrcaService>()
+    private val publisher: EventPublisher = mockk(relaxUnitFun = true)
+    private val repository = mockk<KeelRepository>()
+    private val springEnv: Environment = mockk(relaxUnitFun = true)
+    private val taskLauncher = OrcaTaskLauncher(
+        orcaService,
+        repository,
+        publisher,
+        springEnv
+    )
+    private val resolvers: List<Resolver<*>> = listOf(
+        K8sResolver()
+    )
+    private val decoder: Base64.Decoder = Base64.getMimeDecoder()
+    private val yamlMapper = configuredYamlMapper()
+    private val yaml = """
+        |---
+        |locations:
+        |  account: my-k8s-west-account
+        |  regions: []
+        |metadata:
+        |  application: test
+        |name: test
+        |namespace: test-ns
+        |account: test-git-repo
+    """.trimMargin()
+    private val spec = yamlMapper.readValue(yaml, CredentialsResourceSpec::class.java)
+    private val resource = resource(
+        kind = CREDENTIALS_RESOURCE_SPEC_V1.kind,
+        spec = spec
+    )
+    private val privateKey = """
+        |-----BEGIN OPENSSH PRIVATE KEY-----
+        |b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn
+        |NhAAAAAwEAAQAAAYEA2HUVhOCM5Xni9aITmYYatzpkUYcu57Npd5ugaY7+nhOM1OgvTjYG
+        |ckGSRmO645oWUiQauTZ1gzkpre9WtIyUUUC52ZrTLCBzM7N6TdVcaQ1/UvYRGBmoviV43X
+        |AgMEBQ==
+        |-----END OPENSSH PRIVATE KEY-----
+        """.trimMargin()
+
+    fun tests() = rootContext<CredentialsResourceHandler> {
+        fixture {
+            CredentialsResourceHandler(
+                cloudDriverK8sService,
+                taskLauncher,
+                publisher,
+                orcaService,
+                resolvers
+            )
+        }
+
+        context("credentials exists") {
+            coEvery { cloudDriverK8sService.getCredentialsDetails(any(), "test-git-repo") } returnsMany listOf(
+                GitRepoAccountDetails(token = "token1"),
+                GitRepoAccountDetails(username = "testUser", password = "testPass"),
+                GitRepoAccountDetails(sshPrivateKey = privateKey),
+                GitRepoAccountDetails(token = "token1", password = "doNotUse"),
+                GitRepoAccountDetails(username = "testUser", password = "testPass", sshPrivateKey = privateKey)
+            )
+
+            test("should return a kubernetes secret manifest") {
+                runBlocking {
+                    val result = toResolvedType(resource)
+                    val annotations = result.metadata["annotations"] as Map<String, String>
+                    expectThat(result.metadata) {
+                        hasEntry("name", "test")
+                        hasEntry("namespace", "test-ns")
+                    }
+                    expectThat(annotations["strategy.spinnaker.io/versioned"]).isEqualTo("false")
+                    expectThat(
+                        decoder.decode(result.data?.get("username") as String).toString(Charsets.UTF_8)
+                    ).isEqualTo("token1")
+                    expectThat(result.data?.get("password")).isEqualTo("")
+                }
+            }
+
+            test("should return username and password") {
+                runBlocking {
+                    val result = toResolvedType(resource)
+                    expectThat(
+                        decoder.decode(result.data?.get("username") as String).toString(Charsets.UTF_8)
+                    ).isEqualTo("testUser")
+                    expectThat(
+                        decoder.decode(result.data?.get("password") as String).toString(Charsets.UTF_8)
+                    ).isEqualTo("testPass")
+                }
+            }
+
+            test("should return sshKey") {
+                runBlocking {
+                    val result = toResolvedType(resource)
+                    expectThat(
+                        decoder.decode(result.data?.get("identity") as String).toString(Charsets.UTF_8)
+                    ).isEqualTo(privateKey)
+                }
+            }
+
+            test("should ignore password") {
+                runBlocking {
+                    val result = toResolvedType(resource)
+                    expectThat(
+                        decoder.decode(result.data?.get("username") as String).toString(Charsets.UTF_8)
+                    ).isEqualTo("token1")
+                    expectThat(
+                        decoder.decode(result.data?.get("password") as String).toString(Charsets.UTF_8)
+                    ).isEqualTo("")
+                }
+            }
+
+            test("should ignore ssh key") {
+                runBlocking {
+                    val result = toResolvedType(resource)
+                    expectThat(
+                        decoder.decode(result.data?.get("username") as String).toString(Charsets.UTF_8)
+                    ).isEqualTo("testUser")
+                    expectThat(
+                        decoder.decode(result.data?.get("password") as String).toString(Charsets.UTF_8)
+                    ).isEqualTo("testPass")
+                    expectThat(result.data?.get("identity")).isNull()
+                }
+            }
+        }
+
+        context("resource exists") {
+            before {
+                val manifest = K8sObjectManifest(
+                    apiVersion = "v1",
+                    kind = "Secret",
+                    metadata = mapOf(
+                        "name" to "test",
+                    ),
+                    spec = mutableMapOf<String, Any>() as K8sSpec
+                )
+                clearMocks(cloudDriverK8sService)
+                coEvery {
+                    cloudDriverK8sService.getK8sResource(
+                        any(),
+                        "my-k8s-west-account",
+                        "test-ns",
+                        "secret test"
+                    )
+                } returnsMany listOf(
+                    K8sResourceModel("", null, null, null, manifest, null, null, null, null, null),
+                )
+            }
+
+            test("should return manifest") {
+                runBlocking {
+                    val result = current(resource)
+                    expectThat(result!!.metadata["name"]).isEqualTo("test")
+                }
+            }
+        }
+
+        context("resource does not exists") {
+            before {
+                val notFound: Response<Any> =
+                    Response.error(HttpStatus.NOT_FOUND.value(), ResponseBody.create(null, "not found"))
+                clearMocks(cloudDriverK8sService)
+                coEvery {
+                    cloudDriverK8sService.getK8sResource(
+                        any(),
+                        "my-k8s-west-account",
+                        "test-ns",
+                        "secret test"
+                    )
+                } throws HttpException(notFound)
+            }
+
+            test("should return null") {
+                runBlocking {
+                    val result = current(resource)
+                    expectThat(result).isNull()
+                }
+            }
+        }
+
+        context("actuation is in progress") {
+            before {
+                coEvery { orcaService.getCorrelatedExecutions(resource.spec.name) } returnsMany listOf(
+                    listOf("executionId1"), emptyList()
+                )
+            }
+
+            test("should return correct status") {
+                runBlocking {
+                    val result = actuationInProgress(resource)
+                    val result2 = actuationInProgress(resource)
+                    expectThat(result).isTrue()
+                    expectThat(result2).isFalse()
+                }
+            }
+        }
+    }
+}

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/CredentialsHandlerTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/CredentialsHandlerTest.kt
@@ -56,8 +56,14 @@ class CredentialsHandlerTest : JUnit5Minutests {
         |  regions: []
         |metadata:
         |  application: test
-        |namespace: test-ns
-        |account: test-git-repo
+        |template:
+        |  apiVersion: v1
+        |  kind: Secret
+        |  metadata:
+        |    namespace: test-ns
+        |    type: git
+        |  data:
+        |    account: test-git-repo
     """.trimMargin()
     private val spec = yamlMapper.readValue(yaml, CredentialsResourceSpec::class.java)
     private val resource = resource(
@@ -98,14 +104,14 @@ class CredentialsHandlerTest : JUnit5Minutests {
                     val result = toResolvedType(resource)
                     val annotations = result.metadata["annotations"] as Map<String, String>
                     expectThat(result.metadata) {
-                        hasEntry("name", "test-git-repo")
+                        hasEntry("name", "git-test-git-repo")
                         hasEntry("namespace", "test-ns")
                     }
                     expectThat(annotations["strategy.spinnaker.io/versioned"]).isEqualTo("false")
                     expectThat(
-                        decoder.decode(result.data?.get("username") as String).toString(Charsets.UTF_8)
+                        decoder.decode(result.data?.username as String).toString(Charsets.UTF_8)
                     ).isEqualTo("token1")
-                    expectThat(result.data?.get("password")).isEqualTo("")
+                    expectThat(result.data?.password).isEqualTo("")
                 }
             }
 
@@ -113,10 +119,10 @@ class CredentialsHandlerTest : JUnit5Minutests {
                 runBlocking {
                     val result = toResolvedType(resource)
                     expectThat(
-                        decoder.decode(result.data?.get("username") as String).toString(Charsets.UTF_8)
+                        decoder.decode(result.data?.username as String).toString(Charsets.UTF_8)
                     ).isEqualTo("testUser")
                     expectThat(
-                        decoder.decode(result.data?.get("password") as String).toString(Charsets.UTF_8)
+                        decoder.decode(result.data?.password as String).toString(Charsets.UTF_8)
                     ).isEqualTo("testPass")
                 }
             }
@@ -125,7 +131,7 @@ class CredentialsHandlerTest : JUnit5Minutests {
                 runBlocking {
                     val result = toResolvedType(resource)
                     expectThat(
-                        decoder.decode(result.data?.get("identity") as String).toString(Charsets.UTF_8)
+                        decoder.decode(result.data?.identity as String).toString(Charsets.UTF_8)
                     ).isEqualTo(privateKey)
                 }
             }
@@ -134,10 +140,10 @@ class CredentialsHandlerTest : JUnit5Minutests {
                 runBlocking {
                     val result = toResolvedType(resource)
                     expectThat(
-                        decoder.decode(result.data?.get("username") as String).toString(Charsets.UTF_8)
+                        decoder.decode(result.data?.username as String).toString(Charsets.UTF_8)
                     ).isEqualTo("token1")
                     expectThat(
-                        decoder.decode(result.data?.get("password") as String).toString(Charsets.UTF_8)
+                        decoder.decode(result.data?.password as String).toString(Charsets.UTF_8)
                     ).isEqualTo("")
                 }
             }
@@ -146,12 +152,12 @@ class CredentialsHandlerTest : JUnit5Minutests {
                 runBlocking {
                     val result = toResolvedType(resource)
                     expectThat(
-                        decoder.decode(result.data?.get("username") as String).toString(Charsets.UTF_8)
+                        decoder.decode(result.data?.username as String).toString(Charsets.UTF_8)
                     ).isEqualTo("testUser")
                     expectThat(
-                        decoder.decode(result.data?.get("password") as String).toString(Charsets.UTF_8)
+                        decoder.decode(result.data?.password as String).toString(Charsets.UTF_8)
                     ).isEqualTo("testPass")
-                    expectThat(result.data?.get("identity")).isNull()
+                    expectThat(result.data?.identity).isNull()
                 }
             }
         }
@@ -172,7 +178,7 @@ class CredentialsHandlerTest : JUnit5Minutests {
                         any(),
                         "my-k8s-west-account",
                         "test-ns",
-                        "secret test-git-repo"
+                        "secret git-test-git-repo"
                     )
                 } returnsMany listOf(
                     K8sResourceModel("", null, null, null, manifest, null, null, null, null, null),
@@ -197,7 +203,7 @@ class CredentialsHandlerTest : JUnit5Minutests {
                         any(),
                         "my-k8s-west-account",
                         "test-ns",
-                        "secret test-git-repo"
+                        "secret git-test-git-repo"
                     )
                 } throws HttpException(notFound)
             }
@@ -212,7 +218,7 @@ class CredentialsHandlerTest : JUnit5Minutests {
 
         context("actuation is in progress") {
             before {
-                coEvery { orcaService.getCorrelatedExecutions(resource.spec.account) } returnsMany listOf(
+                coEvery { orcaService.getCorrelatedExecutions("git-test-git-repo") } returnsMany listOf(
                     listOf("executionId1"), emptyList()
                 )
             }

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/DockerImageResolverTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/DockerImageResolverTest.kt
@@ -319,7 +319,7 @@ internal class DockerImageResolverTest : JUnit5Minutests {
     }
 
     fun getImageWithName(r: Resource<K8sResourceSpec>, name: String) : String {
-        val containers = ((r.spec.template.spec["template"] as Map<String, Any>)["spec"] as Map<String, Any>)["containers"] as List<Map<String, Any>>
+        val containers = ((r.spec.template.spec?.get("template") as Map<String, Any>)["spec"] as Map<String, Any>)["containers"] as List<Map<String, Any>>
         containers.filter { it["name"] == name }.also{ return it.first()["image"] as String}
     }
 

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/HelmResourceSpecTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/HelmResourceSpecTest.kt
@@ -49,7 +49,7 @@ internal object HelmResourceSpecTest : JUnit5Minutests {
 
                 test("can be deserialized to a Helm object") {
                     expectThat(this)
-                        .get { template.spec["interval"] }.isEqualTo("5m")
+                        .get { template.spec?.get("interval") }.isEqualTo("5m")
                 }
 
                 test("uses default namespace for Helm resource when namespace missing") {

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/K8sResourceSpecTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/K8sResourceSpecTest.kt
@@ -68,7 +68,7 @@ internal object K8sResourceSpecTests : JUnit5Minutests {
 
                 test("can be deserialized to a K8s object") {
                     expectThat(this)
-                        .get { template.spec["replicas"] }.isEqualTo(2)
+                        .get { template.spec?.get("replicas") }.isEqualTo(2)
                 }
 
                 test("uses default namespace for k8s resource when namespace missing") {


### PR DESCRIPTION
Initial implementation: 
1. Get credentials of type gitRepo from Clouddriver. 
2. Generate kubernetes secret manifest

Resource looks like this:
```
kind: k8s/credentials@v1
spec:
  metadata:
    application: "moretest"
  namespace: keel-dev
  account: manabu-git-repo
```
Made `spec` field nullable in `K8sObjectManifest` since this does not apply to secrets and configMaps.
Generated secrets are named exactly as specifed in `spec.account`. We could let clouddriver version it (e.g. test-secret-v000) but getting and determining the current version becomes more difficult. 

I've also implemented `actuationInProgress()` in the abstract class to prevent jobs being submitted repeatedly. 