### PR TITLE
explicitly register GitRepoCredentials

### DIFF
--- a/k8s-plugin-clouddriver/src/main/kotlin/com/amazon/spinnaker/clouddriver/k8s/ManagedDeliveryK8sPlugin.kt
+++ b/k8s-plugin-clouddriver/src/main/kotlin/com/amazon/spinnaker/clouddriver/k8s/ManagedDeliveryK8sPlugin.kt
@@ -1,5 +1,6 @@
 package com.amazon.spinnaker.clouddriver.k8s
 
+import com.amazon.spinnaker.clouddriver.k8s.controller.CredentialsDetails
 import com.amazon.spinnaker.clouddriver.k8s.services.GitRepoCredentials
 import com.netflix.spinnaker.kork.plugins.api.spring.SpringLoaderPlugin
 import org.pf4j.PluginWrapper
@@ -24,6 +25,7 @@ class ManagedDeliveryK8sPlugin(wrapper: PluginWrapper) : SpringLoaderPlugin(wrap
     override fun registerBeanDefinitions(registry: BeanDefinitionRegistry?) {
         listOf(
             beanDefinitionFor(GitRepoCredentials::class.java),
+            beanDefinitionFor(CredentialsDetails::class.java),
         ).forEach {
             registerBean(it, registry)
         }

--- a/k8s-plugin-clouddriver/src/main/kotlin/com/amazon/spinnaker/clouddriver/k8s/ManagedDeliveryK8sPlugin.kt
+++ b/k8s-plugin-clouddriver/src/main/kotlin/com/amazon/spinnaker/clouddriver/k8s/ManagedDeliveryK8sPlugin.kt
@@ -1,7 +1,9 @@
 package com.amazon.spinnaker.clouddriver.k8s
 
+import com.amazon.spinnaker.clouddriver.k8s.services.GitRepoCredentials
 import com.netflix.spinnaker.kork.plugins.api.spring.SpringLoaderPlugin
 import org.pf4j.PluginWrapper
+import org.springframework.beans.factory.support.BeanDefinitionRegistry
 
 
 class ManagedDeliveryK8sPlugin(wrapper: PluginWrapper) : SpringLoaderPlugin(wrapper) {
@@ -17,5 +19,13 @@ class ManagedDeliveryK8sPlugin(wrapper: PluginWrapper) : SpringLoaderPlugin(wrap
         return listOf(
             "com.amazon.spinnaker.clouddriver.k8s"
         )
+    }
+
+    override fun registerBeanDefinitions(registry: BeanDefinitionRegistry?) {
+        listOf(
+            beanDefinitionFor(GitRepoCredentials::class.java),
+        ).forEach {
+            registerBean(it, registry)
+        }
     }
 }


### PR DESCRIPTION
if the plugin is not embedded into the clouddriver container,
it appears that upon downloading, class loader fails to register
GitRepoCredentials bean only by searching the respective package
where the bean resides. Explictly specifying the bean fixes
the issue