### PR TITLE
use k8s resource status to decide resource health

### DIFF
--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/exception/K8sPluginExceptions.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/exception/K8sPluginExceptions.kt
@@ -1,7 +1,10 @@
 package com.amazon.spinnaker.keel.k8s.exception
 
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.core.ResourceCurrentlyUnresolvable
 import com.netflix.spinnaker.kork.exceptions.IntegrationException
+import java.lang.Exception
 
 class NoDigestFound(repository: String, tag: String) :
     ResourceCurrentlyUnresolvable("No digest found for docker image $repository:$tag in any registry")
@@ -23,3 +26,6 @@ class MisconfiguredObjectException(name: String, value: String, expected: String
 
 class CredResourceTypeMissing(msg: String, e: Throwable? = null):
     ResourceCurrentlyUnresolvable(msg)
+
+class ResourceNotReady(resource: Resource<ResourceSpec>, e: Throwable? = null):
+        Exception("${resource.spec.displayName} is not healthy" )

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/CredentialsHandlerTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/CredentialsHandlerTest.kt
@@ -1,17 +1,20 @@
 package com.amazon.spinnaker.keel.tests
 
 import com.amazon.spinnaker.keel.k8s.CREDENTIALS_RESOURCE_SPEC_V1
+import com.amazon.spinnaker.keel.k8s.K8S_LAST_APPLIED_CONFIG
 import com.amazon.spinnaker.keel.k8s.K8sResourceModel
 import com.amazon.spinnaker.keel.k8s.exception.CouldNotRetrieveCredentials
 import com.amazon.spinnaker.keel.k8s.exception.CredResourceTypeMissing
 import com.amazon.spinnaker.keel.k8s.model.CredentialsResourceSpec
 import com.amazon.spinnaker.keel.k8s.model.GitRepoAccountDetails
 import com.amazon.spinnaker.keel.k8s.model.K8sObjectManifest
+import com.amazon.spinnaker.keel.k8s.model.K8sCredentialManifest
 import com.amazon.spinnaker.keel.k8s.model.K8sSpec
 import com.amazon.spinnaker.keel.k8s.resolver.CredentialsResourceHandler
 import com.amazon.spinnaker.keel.k8s.resolver.K8sResolver
 import com.amazon.spinnaker.keel.k8s.service.CloudDriverK8sService
 import com.netflix.spinnaker.keel.api.Resource
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.support.EventPublisher
 import com.netflix.spinnaker.keel.orca.OrcaService
@@ -82,6 +85,17 @@ class CredentialsHandlerTest : JUnit5Minutests {
         |ckGSRmO645oWUiQauTZ1gzkpre9WtIyUUUC52ZrTLCBzM7N6TdVcaQ1/UvYRGBmoviV43X
         |AgMEBQ==
         |-----END OPENSSH PRIVATE KEY-----
+        """.trimMargin()
+
+    private val expectedSecret = """
+        |apiVersion: v1
+        |kind: Secret
+        |metadata:
+        |  namespace: test-ns
+        |  name: git-test-git-repo
+        |data:
+        |  username: something
+        |  password: something
         """.trimMargin()
 
     fun tests() = rootContext<CredentialsResourceHandler> {
@@ -236,12 +250,17 @@ class CredentialsHandlerTest : JUnit5Minutests {
         }
 
         context("resource exists") {
+            var manifest: K8sObjectManifest
             before {
-                val manifest = K8sObjectManifest(
+                val lastApplied = yamlMapper.readValue(expectedSecret, K8sCredentialManifest::class.java)
+                manifest = K8sObjectManifest(
                     apiVersion = "v1",
                     kind = "Secret",
                     metadata = mapOf(
                         "name" to "test-git-repo",
+                        "annotations" to mapOf(
+                                K8S_LAST_APPLIED_CONFIG to jacksonObjectMapper().writeValueAsString(lastApplied)
+                        )
                     ),
                     spec = mutableMapOf<String, Any>() as K8sSpec
                 )
@@ -261,7 +280,7 @@ class CredentialsHandlerTest : JUnit5Minutests {
             test("should return manifest") {
                 runBlocking {
                     val result = current(resource)
-                    expectThat(result!!.metadata["name"]).isEqualTo("test-git-repo")
+                    expectThat(result!!.metadata["name"]).isEqualTo("git-test-git-repo")
                 }
             }
         }

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/K8sResourceHandlerTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/K8sResourceHandlerTest.kt
@@ -1,6 +1,8 @@
 package com.amazon.spinnaker.keel.tests
 
 import com.amazon.spinnaker.keel.k8s.*
+import com.amazon.spinnaker.keel.k8s.exception.ResourceNotReady
+import com.amazon.spinnaker.keel.k8s.model.Condition
 import com.amazon.spinnaker.keel.k8s.model.K8sResourceSpec
 import com.amazon.spinnaker.keel.k8s.resolver.K8sResolver
 import com.amazon.spinnaker.keel.k8s.resolver.K8sResourceHandler
@@ -16,6 +18,8 @@ import com.netflix.spinnaker.keel.model.OrchestrationRequest
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.OrcaTaskLauncher
 import com.amazon.spinnaker.keel.k8s.model.K8sObjectManifest
+import com.amazon.spinnaker.keel.k8s.model.Status
+import com.netflix.spinnaker.keel.events.ResourceHealthEvent
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
@@ -31,11 +35,10 @@ import retrofit2.HttpException
 import org.springframework.http.HttpStatus
 import org.springframework.core.env.Environment as SpringEnv
 import retrofit2.Response
+import strikt.api.expectCatching
 import strikt.api.expectThat
-import strikt.assertions.get
-import strikt.assertions.isEqualTo
-import strikt.assertions.isFalse
-import strikt.assertions.isTrue
+import strikt.assertions.*
+import java.net.SocketTimeoutException
 import java.util.*
 
 @Suppress("UNCHECKED_CAST")
@@ -94,7 +97,6 @@ internal class K8sResourceHandlerTest : JUnit5Minutests {
     )
 
     private fun resourceModel(replicas: Int = 1, specMap: MutableMap<String, Any?> = mutableMapOf() ) : K8sResourceModel {
-        val mapper = jacksonObjectMapper()
         val lastApplied = yamlMapper.readValue(yaml.replace("replicas: REPLICA", "replicas: ${replicas}"), K8sResourceSpec::class.java)
         return K8sResourceModel(
             account = "my-k8s-west-account",
@@ -107,7 +109,7 @@ internal class K8sResourceHandlerTest : JUnit5Minutests {
                 metadata = mapOf(
                     "name" to "hello-kubernetes",
                     "annotations" to mapOf(
-                        K8S_LAST_APPLIED_CONFIG to mapper.writeValueAsString(lastApplied.template)
+                        K8S_LAST_APPLIED_CONFIG to jacksonObjectMapper().writeValueAsString(lastApplied.template)
                     )
                 ),
                 spec = specMap
@@ -206,9 +208,9 @@ internal class K8sResourceHandlerTest : JUnit5Minutests {
         }
 
         context("the K8s resource has been created"){
+            var resourceModel = resourceModel(1, mutableMapOf("image" to "teset/test:0.1"))
             before {
-                coEvery { cloudDriverK8sService.getK8sResource(any(), any(), any(), any()) } returns
-                        resourceModel(1, mutableMapOf("image" to "teset/test:0.1"))
+                coEvery { cloudDriverK8sService.getK8sResource(any(), any(), any(), any()) } returns resourceModel
             }
 
             test("the diff is clean") {
@@ -229,6 +231,37 @@ internal class K8sResourceHandlerTest : JUnit5Minutests {
                 }
                 test("fires a deployed event") {
                     verify(atLeast = 1) { publisher.publishEvent(ArtifactVersionDeployed(resource.id, "0.1")) }
+                }
+            }
+
+            context("when status is set") {
+                context("with a healthy status") {
+                    before {
+                        resourceModel.manifest.status = Status(
+                            conditions = arrayOf<Condition>(Condition(type = "Ready", status = "True"))
+                        )
+                    }
+
+                    test("deploying the resource succeeds and fires a healthy event"){
+                        runBlocking {
+                            expectCatching { current(resource) }.succeeded()
+                        }
+                        verify(atLeast = 1) { publisher.publishEvent(ResourceHealthEvent(resource, true)) }
+                    }
+                }
+                context("with an unhealthy status") {
+                    before {
+                        resourceModel.manifest.status = Status(
+                            conditions = arrayOf<Condition>(Condition(type = "Ready", status = "False"))
+                        )
+                    }
+
+                    test("deploying the resource fails and fires an unhealthy event"){
+                        runBlocking {
+                            expectCatching { current(resource) }.failed().isA<ResourceNotReady>()
+                        }
+                        verify(atLeast = 1) { publisher.publishEvent(ResourceHealthEvent(resource, false)) }
+                    }
                 }
             }
         }


### PR DESCRIPTION
- check status from cluster resources and if they report
Ready or Available, take the value as an indication of resource health
- refactor resolvers so the evaluation and event emission is only done once