### PR TITLE
Add @Component annotation to GitRepoCredentials

### DIFF
--- a/k8s-plugin-clouddriver/src/main/kotlin/com/amazon/spinnaker/clouddriver/k8s/services/GitRepoCredentials.kt
+++ b/k8s-plugin-clouddriver/src/main/kotlin/com/amazon/spinnaker/clouddriver/k8s/services/GitRepoCredentials.kt
@@ -7,8 +7,10 @@ import com.netflix.spinnaker.clouddriver.artifacts.gitRepo.GitJobExecutor
 import com.netflix.spinnaker.clouddriver.artifacts.gitRepo.GitRepoArtifactCredentials
 import com.netflix.spinnaker.kork.exceptions.MissingCredentialsException
 import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
 import java.io.File
 
+@Component
 class GitRepoCredentials(
     private val artifactCredentialsRepository: ArtifactCredentialsRepository,
 ) {


### PR DESCRIPTION
This fixes the issue mentioned in https://github.com/nimakaviani/managed-delivery-k8s-plugin/pull/33

Tested it against my test plugin repository and it worked as expected:
```
spinnaker:
  extensibility:
    plugins:
      aws.ManagedDeliveryK8sPlugin:
        enabled: true
        version: 1.0.0
    repositories:
      testRepo:
        url: https://raw.githubusercontent.com/nabuskey/ideas/main/k8s-plugin/plugins.json
```

```
curl  'localhost:7002/credentialsDetails/gitRepo/manabu-git-repo'

{"name":"manabu-git-repo","password":"","sshKnownHostsFilePath":"","sshPrivateKey":"","sshPrivateKeyFilePath":"","sshPrivateKeyPassphrase":"","sshPrivateKeyPassphraseCmd":"","sshTrustUnknownHosts":false,"token":"123","username":""}
```
