### PR TITLE
Require keel service

### DIFF
--- a/k8s-plugin/k8s-plugin.gradle
+++ b/k8s-plugin/k8s-plugin.gradle
@@ -18,7 +18,7 @@ repositories {
 spinnakerPlugin {
     serviceName = "keel"
     pluginClass = "com.amazon.spinnaker.keel.k8s.ManagedDeliveryK8sPlugin"
-    requires="orca>=0.0.0"
+    requires="keel>=0.0.0"
     description = 'Plugin to enable K8s in Managed Delivery.'
     version = rootProject.version
 }


### PR DESCRIPTION
This fixes the issue mentioned in https://github.com/nimakaviani/managed-delivery-k8s-plugin/pull/52
This should fix future  releases as well since the `plugin.json` file is populated through the file generated during the build process: https://github.com/nimakaviani/managed-delivery-k8s-plugin/blob/9e3da75ef83cafcb0e639f1eb4ccf598be183177/.github/workflows/release.yml#L71

```
ubuntu@ip-192-168-7-135:~/repos/managed-delivery-k8s-plugin$ cat ./build/distributions/plugin-info.json
{
    "id": "aws.ManagedDeliveryK8sPlugin",
    "description": "K8s support for Managed Delivery",
    "provider": "https://aws.amazon.com",
    "releases": [
        {
            "version": "0.0.5",
            "date": "2021-06-03T17:12:23.615936Z",
            "requires": "keel>=0.0.0,clouddriver>=5.0.0,deck>=0.0.0",
            "sha512sum": "143d2cf0fbba8ddec00fb6bba7ce9056c4f517ef2c565e85df963c82110ec55a45603c5b1ace8918559ef9e836d77086b2312e0f10e1a56c8abd66af098e062f",
            "preferred": false
        }
    ]
}
```