### PR TITLE
Chore/update keel version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 ## Requirements
 
-The managed delivery Kubernetes plugin now integrates with Keel v0.191.1.
+### Version Compatibility
+| Plugin      |   Keel   |
+|:----------- | :--------|
+|  <= 0.0.6  |  0.191.1 |
+
 
 It is also recommended to use Spinnaker Release >  1.25.2 for the most recent
 version of Spinnaker components. For tracking of Docker artifacts and integration with CI (i.e. Jenkins),

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Version Compatibility
 | Plugin      |   Keel   |
 |:----------- | :--------|
-|  <= 0.0.6  |  0.191.1 |
+|  <= 0.0.6   |  0.191.1 |
 
 
 It is also recommended to use Spinnaker Release >  1.25.2 for the most recent

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ pf4jVersion=3.5.0
 korkVersion=7.107.0
 orcaVersion=8.16.0
 kotlinVersion=1.4.21
-keelVersion=0.191.1
+keelVersion=0.194.1
 clouddriverVersion=5.72.1

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/GenericK8sResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/GenericK8sResourceHandler.kt
@@ -15,7 +15,7 @@ import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.plugins.SupportedKind
 import com.netflix.spinnaker.keel.api.support.EventPublisher
 import com.netflix.spinnaker.keel.events.ResourceHealthEvent
-import com.netflix.spinnaker.keel.model.Job
+import com.netflix.spinnaker.keel.model.OrcaJob
 import com.netflix.spinnaker.keel.orca.OrcaService
 import kotlinx.coroutines.coroutineScope
 import mu.KotlinLogging
@@ -105,8 +105,8 @@ abstract class GenericK8sResourceHandler <S: GenericK8sLocatable, R: K8sManifest
         )
     }
 
-    fun R.job(app: String, account: String): Job =
-        Job(
+    fun R.job(app: String, account: String): OrcaJob =
+        OrcaJob(
             "deployManifest",
             mapOf(
                 "moniker" to mapOf(

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/K8sResourceHandlerTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/K8sResourceHandlerTest.kt
@@ -339,7 +339,7 @@ internal class K8sResourceHandlerTest : JUnit5Minutests {
                 val resourceSpec = yamlMapper.readValue(yaml.replace("replicas: REPLICA", "replicas: 1"), K8sResourceSpec::class.java)
                 context("when it is one of the expected annotations") {
                     before{
-                        (resourceSpec.template.metadata as MutableMap<String, Any?>)["annotations"] = mutableMapOf("artifact.spinnaker.io/location" to "something")
+                        (resourceSpec.template.metadata)["annotations"] = mutableMapOf("artifact.spinnaker.io/location" to "something")
                         coEvery { cloudDriverK8sService.getK8sResource(any(), any(), any(), any()) } returns resourceModel(
                             resourceSpec.template
                         )
@@ -355,7 +355,7 @@ internal class K8sResourceHandlerTest : JUnit5Minutests {
                 }
                 context("when it is not one of the expected annotations") {
                     before{
-                        (resourceSpec.template.metadata as MutableMap<String, Any?>)["annotations"] = mutableMapOf("random" to "something")
+                        (resourceSpec.template.metadata)["annotations"] = mutableMapOf("random" to "something")
                         coEvery { cloudDriverK8sService.getK8sResource(any(), any(), any(), any()) } returns resourceModel(
                             resourceSpec.template
                         )
@@ -375,7 +375,7 @@ internal class K8sResourceHandlerTest : JUnit5Minutests {
                 val resourceSpec = yamlMapper.readValue(yaml.replace("replicas: REPLICA", "replicas: 1"), K8sResourceSpec::class.java)
                 context("when it is one of the expected labels") {
                     before{
-                        (resourceSpec.template.metadata as MutableMap<String, Any?>)["labels"] = mutableMapOf("app.kubernetes.io/name" to "something")
+                        (resourceSpec.template.metadata)["labels"] = mutableMapOf("app.kubernetes.io/name" to "something")
                         coEvery { cloudDriverK8sService.getK8sResource(any(), any(), any(), any()) } returns resourceModel(
                             resourceSpec.template
                         )
@@ -391,7 +391,7 @@ internal class K8sResourceHandlerTest : JUnit5Minutests {
                 }
                 context("when it is not one of the expected labels") {
                     before{
-                        (resourceSpec.template.metadata as MutableMap<String, Any?>)["labels"] = mutableMapOf("random" to "something")
+                        (resourceSpec.template.metadata)["labels"] = mutableMapOf("random" to "something")
                         coEvery { cloudDriverK8sService.getK8sResource(any(), any(), any(), any()) } returns resourceModel(
                             resourceSpec.template
                         )


### PR DESCRIPTION
Tested with keel v0.194.1 and works. I did not see any issues with K8s resources or Secrets. We really need a good way to automate integration testing. 