### PR TITLE
Use fully qualified docker image names

### DIFF
--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/exception/K8sPluginExceptions.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/exception/K8sPluginExceptions.kt
@@ -10,7 +10,7 @@ class NoDigestFound(repository: String, tag: String) :
     ResourceCurrentlyUnresolvable("No digest found for docker image $repository:$tag in any registry")
 
 class RegistryNotFound(account: String) :
-    IntegrationException("Unable to find docker registry for titus account $account")
+    IntegrationException("Unable to find docker registry for account $account")
 
 class DuplicateReference(reference: String) :
     IntegrationException("there are duplicate containers with reference $reference")

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/ClouddriverDockerImage.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/ClouddriverDockerImage.kt
@@ -1,0 +1,23 @@
+package com.amazon.spinnaker.keel.k8s.model
+
+data class ClouddriverDockerImage(
+    val account: String,
+    val artifact: Artifact,
+    val digest: String,
+    val registry: String,
+    val repository: String,
+    val tag: String
+)
+
+data class Artifact(
+    val metadata: Metadata,
+    val name: String,
+    val reference: String,
+    val type: String,
+    val version: String
+)
+
+data class Metadata(
+    val labels: Map<String, String>,
+    val registry: String
+)

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/service/CloudDriverK8sService.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/service/CloudDriverK8sService.kt
@@ -1,16 +1,20 @@
 package com.amazon.spinnaker.keel.k8s.service
 
 import com.amazon.spinnaker.keel.k8s.K8sResourceModel
+import com.amazon.spinnaker.keel.k8s.model.ClouddriverDockerImage
 import com.amazon.spinnaker.keel.k8s.model.GitRepoAccountDetails
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.config.DefaultServiceEndpoint
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider
+import com.netflix.spinnaker.keel.clouddriver.model.DockerImage
+import com.netflix.spinnaker.keel.core.api.DEFAULT_SERVICE_ACCOUNT
 import okhttp3.HttpUrl
 import retrofit2.Retrofit
 import retrofit2.converter.jackson.JacksonConverterFactory
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface CloudDriverK8sService {
     @GET("/manifests/{account}/{namespace}/{resource}")
@@ -26,6 +30,16 @@ interface CloudDriverK8sService {
         @Header("X-SPINNAKER-USER") acc: String,
         @Path("account") account: String
     ): GitRepoAccountDetails
+
+    @GET("/dockerRegistry/images/find")
+    suspend fun findDockerImages(
+        @Query("account") account: String? = null,
+        @Query("repository") repository: String? = null,
+        @Query("tag") tag: String? = null,
+        @Query("q") q: String? = null,
+        @Query("includeDetails") includeDetails: Boolean? = null,
+        @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT
+    ): List<ClouddriverDockerImage>
 }
 
 class CloudDriverK8sServiceSupplier(
@@ -49,6 +63,17 @@ class CloudDriverK8sServiceSupplier(
 
     override suspend fun getCredentialsDetails(acc: String, account: String): GitRepoAccountDetails {
         return client.getCredentialsDetails(acc, account)
+    }
+
+    override suspend fun findDockerImages(
+        account: String?,
+        repository: String?,
+        tag: String?,
+        q: String?,
+        includeDetails: Boolean?,
+        user: String
+    ): List<ClouddriverDockerImage> {
+        return client.findDockerImages(account, repository, tag, q, includeDetails, user)
     }
 }
 


### PR DESCRIPTION
Use the reference value from clouddriver to derive docker image names. 

The `invoke` function code is mostly from the super class. I only needed to override one function in the super class but it is not overridable. 


Proper fix should be done in keel but this should fix the issue as well. 
What has to happen in keel for a proper fix:
1. The clouddriver interface needs to be changed in keel once the clouddriver PR is in and published. This is to stop querying all accounts.
2. Keel's clouddriver dependency will also need to be updated.


fixes https://github.com/nimakaviani/managed-delivery-k8s-plugin/issues/63
