### PR TITLE
fix(labeling): add plugin label for resources managed via k8s plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ an application named `spinmd`, your created Kubernetes resources for this applic
 The combination should allow you to query for application resources created by the plugin:
 
 ```bash
-kubectl get all -l md.spinnaker.io/plugin=k8s,app.kubernetes.io/name=spinmd
+kubectl get all -l md.spinnaker.io/plugin=k8s,app.kubernetes.io/name=[YOUR-APP-NAME]
 ```
 
 ## Build and Test

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ More details on the above can be found on the corresponding
 
 ## Deploying to Kubernetes
 
+### Supported Deployments
+
 Support for Kubernetes deployments in the plugin is split into several parts as listed below (expand for details):
 
 <details>
@@ -418,6 +420,19 @@ the `type` of the credential is set to `git`. This in turn will create a secret 
 (prepending the credential type to the account name)
 in the `default` namespace, which can be used in your Flux specification of HELM or Kustomize resources.
 </details>
+
+### Discovering Deployed Resources
+
+- All kubernetes resources deployed via the plugin are labeled with the label `md.spinnaker.io/plugin: k8s`.
+- Spinnaker's clouddriver labels deployed resources with the name of the application, e.g. for
+an application named `spinmd`, your created Kubernetes resources for this application are labeled with
+`app.kubernetes.io/name: spinmd`.
+
+The combination should allow you to query for application resources created by the plugin:
+
+```bash
+kubectl get all -l md.spinnaker.io/plugin=k8s,app.kubernetes.io/name=spinmd
+```
 
 ## Build and Test
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ pf4jVersion=3.5.0
 korkVersion=7.107.0
 orcaVersion=8.16.0
 kotlinVersion=1.4.21
-keelVersion=0.194.1
+keelVersion=0.195.0
 clouddriverVersion=5.72.1

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/K8sConfig.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/K8sConfig.kt
@@ -15,7 +15,9 @@ const val K8S_PROVIDER = "kubernetes"
 const val SOURCE_TYPE = "text"
 
 const val K8S_LAST_APPLIED_CONFIG: String = "kubectl.kubernetes.io/last-applied-configuration"
-const val KEEL_MONIKER_APP: String = "moniker.spinnaker.io/application"
+const val KEEL_MONIKER_APP_ANNOTATION: String = "moniker.spinnaker.io/application"
+const val MANAGED_DELIVERY_APP_LABEL = "md.spinnaker.io/plugin"
+const val MANAGED_DELIVERY_K8S_PLUGIN = "k8s"
 
 const val NAME: String = "name"
 const val NAMESPACE: String = "namespace"

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/K8sConfig.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/K8sConfig.kt
@@ -11,13 +11,12 @@ val HELM_RESOURCE_SPEC_V1 = kind <HelmResourceSpec>("k8s/helm@v1")
 val KUSTOMIZE_RESOURCE_SPEC_V1 = kind <KustomizeResourceSpec>("k8s/kustomize@v1")
 val CREDENTIALS_RESOURCE_SPEC_V1 = kind <CredentialsResourceSpec>("k8s/credential@v1")
 
+val MANAGED_DELIVERY_PLUGIN_LABELS = listOf(Pair("md.spinnaker.io/plugin", "k8s"))
+
 const val K8S_PROVIDER = "kubernetes"
 const val SOURCE_TYPE = "text"
 
 const val K8S_LAST_APPLIED_CONFIG: String = "kubectl.kubernetes.io/last-applied-configuration"
-const val KEEL_MONIKER_APP_ANNOTATION: String = "moniker.spinnaker.io/application"
-const val MANAGED_DELIVERY_APP_LABEL = "md.spinnaker.io/plugin"
-const val MANAGED_DELIVERY_K8S_PLUGIN = "k8s"
 
 const val NAME: String = "name"
 const val NAMESPACE: String = "namespace"

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/HelmResourceSpec.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/HelmResourceSpec.kt
@@ -5,7 +5,7 @@ import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.docker.ReferenceProvider
 
 class HelmResourceSpec (
-    val chart: ReferenceProvider?,
+    val chart: ReferenceProvider? = null,
     override val metadata: Map<String, String>,
     override val template: K8sObjectManifest,
     override val locations: SimpleLocations,

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/CredentialsResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/CredentialsResourceHandler.kt
@@ -79,17 +79,27 @@ class CredentialsResourceHandler(
             }
         }
         // setting strategy.spinnaker.io/versioned is needed to avoid creating secrets with versioned names e.g. testing1-v000
-        return K8sCredentialManifest(
-            SECRET_API_V1,
-            SECRET,
-            mutableMapOf(
-                "namespace" to resource.spec.namespace,
-                "name" to "${credType}-${clouddriverAccountName}",
-                "annotations" to mapOf("strategy.spinnaker.io/versioned" to "false")
-            ),
-            null,
-            data.toK8sBlob() as K8sBlob?
+        val copyResource = Resource(
+            kind = resource.kind,
+            metadata = resource.metadata,
+            spec = CredentialsResourceSpec(
+               locations = resource.spec.locations,
+               metadata  = resource.spec.metadata,
+               template = K8sCredentialManifest(
+                    SECRET_API_V1,
+                    SECRET,
+                    mutableMapOf(
+                        "namespace" to resource.spec.namespace,
+                        "name" to "${credType}-${clouddriverAccountName}",
+                        "annotations" to mapOf("strategy.spinnaker.io/versioned" to "false")
+                    ),
+                    null,
+                    data.toK8sBlob() as K8sBlob?
+                )
+            )
         )
+        // sending it to the super class for common labels and annotations to be added
+        return super.toResolvedType(copyResource)
     }
 
     override suspend fun current(resource: Resource<CredentialsResourceSpec>): K8sCredentialManifest? =

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/GenericK8sResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/GenericK8sResourceHandler.kt
@@ -44,10 +44,12 @@ abstract class GenericK8sResourceHandler <S: GenericK8sLocatable, R: K8sManifest
                     it as MutableMap<String, String>
                 }
 
-                labels[MANAGED_DELIVERY_APP_LABEL]  = MANAGED_DELIVERY_K8S_PLUGIN
+                MANAGED_DELIVERY_PLUGIN_LABELS.forEach{ label ->
+                    labels[label.first]  = label.second
+                }
                 this.template!!.metadata[LABELS] = labels
                 (this.template as K8sManifest).spec?.let{ spec ->
-                    augmentWithLabels(spec, listOf(Pair(MANAGED_DELIVERY_APP_LABEL, MANAGED_DELIVERY_K8S_PLUGIN)))
+                    augmentWithLabels(spec, MANAGED_DELIVERY_PLUGIN_LABELS)
                 }
             }
 

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/HelmResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/HelmResourceHandler.kt
@@ -2,22 +2,16 @@ package com.amazon.spinnaker.keel.k8s.resolver
 
 import com.amazon.spinnaker.keel.k8s.*
 import com.amazon.spinnaker.keel.k8s.exception.MisconfiguredObjectException
-import com.amazon.spinnaker.keel.k8s.exception.ResourceNotReady
 import com.amazon.spinnaker.keel.k8s.model.HelmResourceSpec
 import com.amazon.spinnaker.keel.k8s.model.K8sObjectManifest
-import com.amazon.spinnaker.keel.k8s.model.isReady
 import com.amazon.spinnaker.keel.k8s.service.CloudDriverK8sService
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.ResourceDiff
-import com.netflix.spinnaker.keel.api.actuation.Task
 import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.support.EventPublisher
-import com.netflix.spinnaker.keel.events.ResourceHealthEvent
 import com.netflix.spinnaker.keel.orca.OrcaService
-import kotlinx.coroutines.coroutineScope
 
 class HelmResourceHandler(
     override val cloudDriverK8sService: CloudDriverK8sService,
@@ -44,12 +38,11 @@ class HelmResourceHandler(
             throw MisconfiguredObjectException(e.message!!)
         }
 
-        return K8sObjectManifest(
-            FLUX_HELM_API_VERSION,
-            FLUX_HELM_KIND,
-            resource.spec.template.metadata,
-            resource.spec.template.spec
-        )
+        resource.spec.template.apiVersion = FLUX_HELM_API_VERSION
+        resource.spec.template.kind = FLUX_HELM_KIND
+
+        // sending it to the super class for common labels and annotations to be added
+        return super.toResolvedType(resource)
     }
 
     override suspend fun current(resource: Resource<HelmResourceSpec>): K8sObjectManifest? =

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/K8sResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/K8sResourceHandler.kt
@@ -40,7 +40,8 @@ class K8sResourceHandler (
                 }
             }
         }
-        return resource.spec.template
+        // sending it to the super class for common labels and annotations to be added
+        return super.toResolvedType(resource)
     }
 
     override suspend fun current(resource: Resource<K8sResourceSpec>): K8sObjectManifest? =

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/KustomizeResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/KustomizeResourceHandler.kt
@@ -2,20 +2,16 @@ package com.amazon.spinnaker.keel.k8s.resolver
 
 import com.amazon.spinnaker.keel.k8s.*
 import com.amazon.spinnaker.keel.k8s.exception.MisconfiguredObjectException
-import com.amazon.spinnaker.keel.k8s.model.HelmResourceSpec
 import com.amazon.spinnaker.keel.k8s.model.KustomizeResourceSpec
 import com.amazon.spinnaker.keel.k8s.model.K8sObjectManifest
 import com.amazon.spinnaker.keel.k8s.service.CloudDriverK8sService
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.ResourceDiff
-import com.netflix.spinnaker.keel.api.actuation.Task
 import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.support.EventPublisher
 import com.netflix.spinnaker.keel.orca.OrcaService
-import kotlinx.coroutines.coroutineScope
 
 class KustomizeResourceHandler(
     override val cloudDriverK8sService: CloudDriverK8sService,
@@ -42,12 +38,11 @@ class KustomizeResourceHandler(
             throw MisconfiguredObjectException(e.message!!)
         }
 
-        return K8sObjectManifest(
-            FLUX_KUSTOMIZE_API_VERSION,
-            FLUX_KUSTOMIZE_KIND,
-            resource.spec.template.metadata,
-            resource.spec.template.spec
-        )
+        resource.spec.template.apiVersion = FLUX_KUSTOMIZE_API_VERSION
+        resource.spec.template.kind = FLUX_KUSTOMIZE_KIND
+
+        // sending it to the super class for common labels and annotations to be added
+        return super.toResolvedType(resource)
     }
 
     override suspend fun current(resource: Resource<KustomizeResourceSpec>): K8sObjectManifest? =

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/CredentialsHandlerTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/CredentialsHandlerTest.kt
@@ -64,7 +64,7 @@ class CredentialsHandlerTest : JUnit5Minutests {
         |  account: my-k8s-west-account
         |  regions: []
         |metadata:
-        |  application: test
+        |  application: fnord
         |template:
         |  metadata:
         |    namespace: test-ns

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/CredentialsResourceSpecTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/CredentialsResourceSpecTest.kt
@@ -26,7 +26,7 @@ class CredentialsResourceSpecTest : JUnit5Minutests {
                         |  account: my-k8s-west-account
                         |  regions: []
                         |metadata:
-                        |  application: test
+                        |  application: fnord
                         |template:
                         |  metadata:
                         |    namespace: default

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/DockerImageResolverTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/DockerImageResolverTest.kt
@@ -43,7 +43,7 @@ internal class DockerImageResolverTest : JUnit5Minutests {
         kind = K8S_RESOURCE_SPEC_V1.kind,
         metadata = mapOf(
             "id" to "deployment",
-            "application" to "test",
+            "application" to "fnord",
             "serviceAccount" to "keel@spinnaker"
         ),
         spec = K8sResourceSpec(
@@ -54,7 +54,7 @@ internal class DockerImageResolverTest : JUnit5Minutests {
                 account = "test",
                 regions = emptySet()
             ),
-            metadata = mapOf("application" to "test"),
+            metadata = mapOf("application" to "fnord"),
             template = K8sObjectManifest(
                 apiVersion = "apps/v1",
                 kind = "Deployment",
@@ -77,7 +77,7 @@ internal class DockerImageResolverTest : JUnit5Minutests {
         kind = K8S_RESOURCE_SPEC_V1.kind,
         metadata = mapOf(
             "id" to "service",
-            "application" to "test"
+            "application" to "fnord"
         ),
         spec = K8sResourceSpec(
             container = null,
@@ -85,7 +85,7 @@ internal class DockerImageResolverTest : JUnit5Minutests {
                 account = "test",
                 regions = emptySet()
             ),
-            metadata = mapOf("application" to "test"),
+            metadata = mapOf("application" to "fnord"),
             template = K8sObjectManifest(
                 apiVersion = "v1",
                 kind = "Service",

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/HelmResourceHandlerTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/HelmResourceHandlerTest.kt
@@ -60,7 +60,7 @@ internal class HelmResourceHandlerTest : JUnit5Minutests {
         |  account: my-k8s-west-account
         |  regions: []
         |metadata:
-        |  application: test
+        |  application: fnord
         |template:
         |  metadata:
         |    name: hello-kubernetes
@@ -74,7 +74,7 @@ internal class HelmResourceHandlerTest : JUnit5Minutests {
         |  account: my-k8s-west-account
         |  regions: []
         |metadata:
-        |  application: test
+        |  application: fnord
         |template:
         |  apiVersion: helm.toolkit.fluxcd.io/v2beta1
         |  kind: HelmRelease
@@ -90,7 +90,7 @@ internal class HelmResourceHandlerTest : JUnit5Minutests {
         |  account: my-k8s-west-account
         |  regions: []
         |metadata:
-        |  application: test
+        |  application: fnord
         |template:
         |  apiVersion: something
         |  kind: HelmRelease
@@ -106,12 +106,14 @@ internal class HelmResourceHandlerTest : JUnit5Minutests {
         |  account: my-k8s-west-account
         |  regions: []
         |metadata:
-        |  application: test
+        |  application: fnord
         |template:
         |  apiVersion: helm.toolkit.fluxcd.io/v2beta1
         |  kind: HelmRelease
         |  metadata:
         |    name: hello-kubernetes
+        |    labels:
+        |      md.spinnaker.io/plugin: k8s
         |  spec:
         |    url: some-url
     """.trimMargin()
@@ -137,7 +139,7 @@ internal class HelmResourceHandlerTest : JUnit5Minutests {
             ),
             metrics = emptyList(),
             moniker = null,
-            name = "test",
+            name = "fnord",
             status = emptyMap(),
             warnings = emptyList()
         )

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/HelmResourceSpecTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/HelmResourceSpecTest.kt
@@ -29,7 +29,7 @@ internal object HelmResourceSpecTest : JUnit5Minutests {
                         |  account: my-k8s-west-account
                         |  regions: []
                         |metadata:
-                        |  application: test
+                        |  application: fnord
                         |template:
                         |  apiVersion: source.toolkit.fluxcd.io/v1beta1
                         |  kind: HelmRepository
@@ -59,7 +59,7 @@ internal object HelmResourceSpecTest : JUnit5Minutests {
 
                 test("stores correct application metadata from the spec") {
                     expectThat(this)
-                        .get { metadata["application"] }.isEqualTo("test")
+                        .get { metadata["application"] }.isEqualTo("fnord")
                 }
 
                 test("has chart information properly stored") {

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/K8sResourceHandlerTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/K8sResourceHandlerTest.kt
@@ -473,7 +473,7 @@ internal class K8sResourceHandlerTest : JUnit5Minutests {
                     expectThat(metadata)
                         .hasEntry("name", "hello-kubernetes")
                         .hasEntry("namespace", "hello")
-                        .hasEntry("labels", mutableMapOf(MANAGED_DELIVERY_APP_LABEL to "k8s"))
+                        .hasEntry("labels", mutableMapOf("md.spinnaker.io/plugin" to "k8s"))
                         .hasSize(3)
                 }
             }

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/K8sResourceSpecTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/K8sResourceSpecTest.kt
@@ -26,7 +26,7 @@ internal object K8sResourceSpecTests : JUnit5Minutests {
                         |  account: my-k8s-west-account
                         |  regions: []
                         |metadata:
-                        |  application: test
+                        |  application: fnord
                         |template:
                         |  apiVersion: "apps/v1"
                         |  kind: Deployment
@@ -78,7 +78,7 @@ internal object K8sResourceSpecTests : JUnit5Minutests {
 
                 test("stores correct application metadata from the spec") {
                     expectThat(this)
-                        .get { metadata["application"] }.isEqualTo("test")
+                        .get { metadata["application"] }.isEqualTo("fnord")
                 }
             }
         }

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/KustomizeResourceHandlerTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/KustomizeResourceHandlerTest.kt
@@ -60,7 +60,7 @@ internal class KustomizeResourceHandlerTest : JUnit5Minutests {
         |  account: my-k8s-west-account
         |  regions: []
         |metadata:
-        |  application: test
+        |  application: fnord
         |template:
         |  metadata:
         |    name: hello-kubernetes
@@ -74,7 +74,7 @@ internal class KustomizeResourceHandlerTest : JUnit5Minutests {
         |  account: my-k8s-west-account
         |  regions: []
         |metadata:
-        |  application: test
+        |  application: fnord
         |template:
         |  apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
         |  kind: Kustomization
@@ -90,7 +90,7 @@ internal class KustomizeResourceHandlerTest : JUnit5Minutests {
         |  account: my-k8s-west-account
         |  regions: []
         |metadata:
-        |  application: test
+        |  application: fnord
         |template:
         |  apiVersion: something
         |  kind: Kustomization
@@ -106,12 +106,14 @@ internal class KustomizeResourceHandlerTest : JUnit5Minutests {
         |  account: my-k8s-west-account
         |  regions: []
         |metadata:
-        |  application: test
+        |  application: fnord
         |template:
         |  apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
         |  kind: Kustomization
         |  metadata:
         |    name: hello-kubernetes
+        |    labels:
+        |      md.spinnaker.io/plugin: k8s
         |  spec:
         |    url: some-url
     """.trimMargin()
@@ -137,7 +139,7 @@ internal class KustomizeResourceHandlerTest : JUnit5Minutests {
             ),
             metrics = emptyList(),
             moniker = null,
-            name = "test",
+            name = "fnord",
             status = emptyMap(),
             warnings = emptyList()
         )


### PR DESCRIPTION
this in combination with the application name that is added to all spinnaker
resources allows users to filter out k8s resources created through  managed delivery.

fixes #42