### PR TITLE
docs(docker): trackDigests boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ dockerRegistry:
 accounts:
 - address: https://index.docker.io # example registry
   name: "[K8s-ACCOUNT-NAME]-registry"
+  trackDigests: true
   repositories:
   - example/service
 ```


### PR DESCRIPTION
In order for clouddriver to reply back with `digest` to keel, we had to enable the trackDigests boolean in the dockerRegistry config.