### PR TITLE
add labels for account type and account name of a generated secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,9 +419,21 @@ where the value for `account:` corresponds to the name of the account in your Cl
 the `type` of the credential is set to `git`. This in turn will create a secret named `git-sample-repo` 
 (prepending the credential type to the account name)
 in the `default` namespace, which can be used in your Flux specification of HELM or Kustomize resources.
+
+All secrets generated from clouddriver account information are tagged with the following two tags:
+
+- `account.clouddriver.spinnaker.io/name=[CLOUDDRIVER-ACCOUNT-NAME]`
+- `account.clouddriver.spinnaker.io/type=[CLOUDDRIVER-ACCOUNT-TYPE]` (e.g. `git`)
+
+Generated secrets can be discovered like the following as an example:
+
+```
+kubectl get secrets -l account.clouddriver.spinnaker.io/type=git
+```
+
 </details>
 
-### Discovering Deployed Resources
+### Discovering Resources
 
 - All kubernetes resources deployed via the plugin are labeled with the label `md.spinnaker.io/plugin: k8s`.
 - Spinnaker's clouddriver labels deployed resources with the name of the application, e.g. for

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/K8sConfig.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/K8sConfig.kt
@@ -12,6 +12,8 @@ val KUSTOMIZE_RESOURCE_SPEC_V1 = kind <KustomizeResourceSpec>("k8s/kustomize@v1"
 val CREDENTIALS_RESOURCE_SPEC_V1 = kind <CredentialsResourceSpec>("k8s/credential@v1")
 
 val MANAGED_DELIVERY_PLUGIN_LABELS = listOf(Pair("md.spinnaker.io/plugin", "k8s"))
+const val CLOUDDRIVER_ACCOUNT_NAME_LABEL = "account.clouddriver.spinnaker.io/name"
+const val CLOUDDRIVER_ACCOUNT_TYPE_LABEL = "account.clouddriver.spinnaker.io/type"
 
 const val K8S_PROVIDER = "kubernetes"
 const val SOURCE_TYPE = "text"

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/CredentialsResourceHandler.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/CredentialsResourceHandler.kt
@@ -91,7 +91,11 @@ class CredentialsResourceHandler(
                     mutableMapOf(
                         "namespace" to resource.spec.namespace,
                         "name" to "${credType}-${clouddriverAccountName}",
-                        "annotations" to mapOf("strategy.spinnaker.io/versioned" to "false")
+                        "annotations" to mapOf("strategy.spinnaker.io/versioned" to "false"),
+                        "labels" to mapOf(
+                            CLOUDDRIVER_ACCOUNT_NAME_LABEL to clouddriverAccountName,
+                            CLOUDDRIVER_ACCOUNT_TYPE_LABEL to credType
+                        )
                     ),
                     null,
                     data.toK8sBlob() as K8sBlob?

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/CredentialsHandlerTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/CredentialsHandlerTest.kt
@@ -180,6 +180,11 @@ class CredentialsHandlerTest : JUnit5Minutests {
                     expectThat(result.metadata) {
                         hasEntry("name", "git-test-git-repo")
                         hasEntry("namespace", "test-ns")
+                        hasEntry("labels", mutableMapOf(
+                            "account.clouddriver.spinnaker.io/name" to "test-git-repo",
+                            "account.clouddriver.spinnaker.io/type" to "git",
+                            "md.spinnaker.io/plugin" to "k8s"
+                        ))
                     }
                     expectThat(annotations["strategy.spinnaker.io/versioned"]).isEqualTo("false")
                     expectThat(


### PR DESCRIPTION
adds the following labels to the generated secrets:

account.clouddriver.spinnaker.io/name
account.clouddriver.spinnaker.io/type

fixes #56