### PR TITLE
Initial implementation of igor plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ spinnaker:
           id: awsManagedDeliveryK8sPluginRepo
           url: https://raw.githubusercontent.com/nimakaviani/managed-delivery-k8s-plugin/master/plugins.json
 ```
+### Igor plugin configuration
+Igor plugin is optional. Only needed when you would like to deploy K8s resources through Kustomize files in GitHub.
+
+The access token provided in the config file is expected to have READ access to repositories defined 
+```yaml
+github:
+  baseUrl: "https://api.github.com"
+  accessToken: TOKEN
+git:
+  repositories: 
+    - name: managed-delivery-k8s-plugin
+      type: github
+      project: nimakaviani
+      url: https://github.com/nimakaviani/managed-delivery-k8s-plugin.git
+```
+
 ## Delivery Config Manifest
 
 By defining the _Delivery Config Manifest_, you can control the deployment and progression of resources to different

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,4 @@ orcaVersion=8.16.0
 kotlinVersion=1.4.21
 keelVersion=0.195.0
 clouddriverVersion=5.72.1
+igorVersion=4.5.1

--- a/k8s-plugin-igor/k8s-plugin-igor.gradle
+++ b/k8s-plugin-igor/k8s-plugin-igor.gradle
@@ -1,0 +1,76 @@
+
+apply plugin: "java-library"
+apply plugin: "io.spinnaker.plugin.service-extension"
+apply plugin: "maven-publish"
+apply plugin: "kotlin"
+apply plugin: "kotlin-kapt"
+
+sourceCompatibility = 11
+targetCompatibility = 11
+
+repositories {
+    gradlePluginPortal()
+    mavenCentral()
+    if (property("korkVersion").toString().endsWith("-SNAPSHOT")) {
+        mavenLocal()
+    }
+}
+
+spinnakerPlugin {
+    serviceName = "igor"
+    pluginClass = "com.amazon.spinnaker.igor.k8s.ManagedDeliveryK8sPlugin"
+    requires="igor>=0.0.0"
+    description = 'Plugin to enable K8s in Managed Delivery.'
+    version = rootProject.version
+}
+
+dependencies {
+//    compileOnly ("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:${kotlinVersion}")
+    implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2")
+    compileOnly (group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.11.1')
+    compileOnly (group: 'io.spinnaker.igor', name: 'igor-core', version: "${igorVersion}")
+    compileOnly (group: 'io.spinnaker.igor', name: 'igor-web', version: "${igorVersion}")
+    compileOnly (group: 'io.spinnaker.kork', name: 'kork-plugins-api', version: "${korkVersion}")
+    compileOnly (group: 'io.spinnaker.kork', name: 'kork-plugins-spring-api', version: "${korkVersion}")
+    compileOnly (group: 'io.spinnaker.kork', name: 'kork-core', version: "${korkVersion}")
+    compileOnly (group: 'io.spinnaker.kork', name: 'kork-jedis', version: "${korkVersion}")
+    compileOnly (group: 'io.spinnaker.kork', name: 'kork-web', version: "${korkVersion}")
+    compileOnly (group: 'io.spinnaker.kork', name: 'kork-artifacts', version: "${korkVersion}")
+    compileOnly (group: 'com.squareup.retrofit', name: 'retrofit', version: "1.9.0")
+    compileOnly (group: 'com.squareup.retrofit', name: 'converter-jackson', version: "1.9.0")
+    compileOnly (group: 'org.codehaus.groovy', name: 'groovy-all', version: "2.5.11")
+    kapt(group: 'org.pf4j', name: 'pf4j', version: "${pf4jVersion}")
+
+    testImplementation ("org.junit.jupiter:junit-jupiter-api:5.7.2")
+    testImplementation (group: 'io.strikt', name: 'strikt-core', version: '0.31.0')
+    testImplementation (group: 'io.mockk', name: 'mockk', version: '1.11.0')
+    testImplementation (group: 'io.spinnaker.igor', name: 'igor-core', version: "${igorVersion}")
+    testImplementation (group: 'io.spinnaker.igor', name: 'igor-web', version: "${igorVersion}")
+    testImplementation (group: 'io.spinnaker.kork', name: 'kork-plugins-api', version: "${korkVersion}")
+    testImplementation (group: 'io.spinnaker.kork', name: 'kork-plugins-spring-api', version: "${korkVersion}")
+    testImplementation (group: 'io.spinnaker.kork', name: 'kork-core', version: "${korkVersion}")
+    testImplementation (group: 'io.spinnaker.kork', name: 'kork-jedis', version: "${korkVersion}")
+    testImplementation (group: 'io.spinnaker.kork', name: 'kork-web', version: "${korkVersion}")
+    testImplementation (group: 'io.spinnaker.kork', name: 'kork-artifacts', version: "${korkVersion}")
+
+}
+
+tasks.withType(Test) {
+    useJUnitPlatform()
+}
+
+compileKotlin {
+    kotlinOptions {
+        languageVersion = "1.4"
+        jvmTarget = targetCompatibility
+        freeCompilerArgs = ['-Xjvm-default=enable']
+    }
+}
+
+compileTestKotlin {
+    kotlinOptions {
+        languageVersion = "1.4"
+        jvmTarget = targetCompatibility
+        freeCompilerArgs = ['-Xjvm-default=enable']
+    }
+}

--- a/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/ManagedDeliveryK8sPlugin.kt
+++ b/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/ManagedDeliveryK8sPlugin.kt
@@ -1,0 +1,37 @@
+package com.amazon.spinnaker.igor.k8s
+
+import com.amazon.spinnaker.igor.k8s.cache.GitCache
+import com.amazon.spinnaker.igor.k8s.config.GitHubAccounts
+import com.amazon.spinnaker.igor.k8s.config.GitHubRestClient
+import com.amazon.spinnaker.igor.k8s.config.PluginConfigurationProperties
+import com.amazon.spinnaker.igor.k8s.controller.GitVersionController
+import com.amazon.spinnaker.igor.k8s.monitor.GitHubMonitor
+import com.amazon.spinnaker.igor.k8s.service.GitControllerService
+import com.netflix.spinnaker.kork.plugins.api.spring.PrivilegedSpringPlugin
+import org.pf4j.PluginWrapper
+import org.springframework.beans.factory.support.BeanDefinitionRegistry
+
+//    Must use PrivilegedSpringPlugin because plugin initiation is done too late in SpringLoaderPlugin
+class ManagedDeliveryK8sPlugin(wrapper: PluginWrapper) : PrivilegedSpringPlugin(wrapper) {
+    override fun start() {
+        log.info("starting ManagedDelivery k8s plugin.")
+    }
+
+    override fun stop() {
+        log.info("stopping ManagedDelivery k8s plugin.")
+    }
+
+    override fun registerBeanDefinitions(registry: BeanDefinitionRegistry?) {
+        listOf(
+            beanDefinitionFor(GitHubRestClient::class.java),
+            beanDefinitionFor(GitHubAccounts::class.java),
+            beanDefinitionFor(GitHubMonitor::class.java),
+            beanDefinitionFor(GitControllerService::class.java),
+            beanDefinitionFor(GitVersionController::class.java),
+            beanDefinitionFor(PluginConfigurationProperties::class.java),
+            beanDefinitionFor(GitCache::class.java),
+        ).forEach {
+            registerBean(it, registry)
+        }
+    }
+}

--- a/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/cache/GitCache.kt
+++ b/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/cache/GitCache.kt
@@ -1,0 +1,70 @@
+package com.amazon.spinnaker.igor.k8s.cache
+
+import com.amazon.spinnaker.igor.k8s.model.GitPollingDelta
+import com.amazon.spinnaker.igor.k8s.model.GitVersion
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.netflix.spinnaker.igor.IgorConfigurationProperties
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class GitCache(
+    val redisClientDelegate: RedisClientDelegate,
+    private val igorConfigurationProperties: IgorConfigurationProperties
+) {
+    private val id = "git"
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val mapper = jacksonObjectMapper()
+
+    fun getVersionKeys(type: String, project: String, name: String): Set<String> {
+        val result = mutableSetOf<String>()
+        redisClientDelegate.withKeyScan(
+            makeIndexPattern(type, project, name),
+            1000
+        ) {
+            result.addAll(it.results)
+        }
+        return result.toSet()
+    }
+
+    fun cacheVersion(gitPollingDelta: GitPollingDelta) {
+        redisClientDelegate.withPipeline {
+            gitPollingDelta.deltas.forEach { delta ->
+                log.debug("caching $delta")
+                it.hset(delta.toString(), delta.toMap())
+            }
+            redisClientDelegate.syncPipeline(it)
+        }
+    }
+
+    fun getVersions(type: String, project: String, name: String): Set<GitVersion> {
+        val keys = getVersionKeys(type, project, name)
+        val versions = mutableSetOf<GitVersion>()
+        keys.forEach {
+            versions.add(getVersion(it))
+        }
+        return versions
+    }
+
+    fun getVersion(key: String): GitVersion {
+        var resultMap = emptyMap<String, String>()
+        redisClientDelegate.withCommandsClient {
+            resultMap = it.hgetAll(key)
+        }
+        return mapper.convertValue(resultMap, object: TypeReference<GitVersion>() {})
+    }
+
+    fun getVersion(type: String, project: String, name: String, version: String): GitVersion {
+        return getVersion(makeVersionKey(type, project, name, version))
+    }
+
+    private fun makeIndexPattern(type: String, project: String, name: String): String {
+        return "${igorConfigurationProperties.spinnaker.jedis.prefix}:$id:$type:$project:$name:*"
+    }
+
+    private fun makeVersionKey(type: String, project: String, name: String, version: String): String {
+        return "${igorConfigurationProperties.spinnaker.jedis.prefix}:$id:$type:$project:$name:$version"
+    }
+}

--- a/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/config/GitHubConfiguration.kt
+++ b/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/config/GitHubConfiguration.kt
@@ -1,0 +1,51 @@
+package com.amazon.spinnaker.igor.k8s.config
+
+import com.amazon.spinnaker.igor.k8s.model.GitHubAccount
+import com.amazon.spinnaker.igor.k8s.service.GitHubService
+import com.netflix.spinnaker.igor.config.GitHubProperties
+import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Configuration
+import retrofit.Endpoints
+import retrofit.RestAdapter
+import retrofit.client.OkClient
+import retrofit.converter.JacksonConverter
+
+@Configuration
+@ConditionalOnProperty("github.base-url")
+open class GitHubRestClient(gitHubProperties: GitHubProperties) {
+    var client: GitHubService
+
+    init {
+        val baseUrlField = GitHubProperties::class.java.getDeclaredField("baseUrl")
+        val accessTokenField = GitHubProperties::class.java.getDeclaredField("accessToken")
+        baseUrlField.isAccessible = true
+        accessTokenField.isAccessible = true
+        val baseUrl = baseUrlField.get(gitHubProperties) as String
+        val accessToken = accessTokenField.get(gitHubProperties) as String
+        client = RestAdapter.Builder()
+            .setEndpoint(Endpoints.newFixedEndpoint(baseUrl))
+            .setRequestInterceptor {
+                it.addHeader("Authorization", "token $accessToken")
+            }
+            .setClient(OkClient())
+            .setConverter(JacksonConverter())
+            .setLog(Slf4jRetrofitLogger(GitHubService::class.java))
+            .build()
+            .create(GitHubService::class.java)
+    }
+}
+
+open class GitHubAccounts(pluginConfigurationProperties: PluginConfigurationProperties) {
+    lateinit var accounts: MutableList<GitHubAccount>
+
+    init {
+        pluginConfigurationProperties.repositories.forEach {
+            val gitHubAccounts = mutableListOf<GitHubAccount>()
+            if (it.type.toLowerCase() == "github") {
+                gitHubAccounts.add(GitHubAccount(name = it.name, project = it.project, url = it.url))
+            }
+            accounts = gitHubAccounts
+        }
+    }
+}

--- a/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/config/PluginConfiguration.kt
+++ b/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/config/PluginConfiguration.kt
@@ -1,0 +1,11 @@
+package com.amazon.spinnaker.igor.k8s.config
+
+import com.amazon.spinnaker.igor.k8s.model.GitAccount
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "git")
+class PluginConfigurationProperties {
+    var repositories: MutableList<GitAccount> = mutableListOf()
+    var enabled: Boolean = false
+}
+

--- a/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/controller/GitVersionController.kt
+++ b/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/controller/GitVersionController.kt
@@ -1,0 +1,43 @@
+package com.amazon.spinnaker.igor.k8s.controller
+
+import com.amazon.spinnaker.igor.k8s.model.GitVersion
+import com.amazon.spinnaker.igor.k8s.service.GitControllerService
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.util.MimeTypeUtils
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping(path = ["/git"])
+@ConditionalOnProperty("artifacts.gitrepo.enabled")
+class GitVersionController(
+    private val gitControllerService: GitControllerService,
+) {
+
+    @GetMapping(
+        path = ["/version/{type}/{project}/{slug}"],
+        produces = [MimeTypeUtils.APPLICATION_JSON_VALUE]
+    )
+    fun getGitVersions(
+        @PathVariable("type") type: String,
+        @PathVariable("project") project: String,
+        @PathVariable("slug") slug: String
+    ): List<GitVersion> {
+        return gitControllerService.getVersions(type, project, slug)
+    }
+
+    @GetMapping(
+        path = ["/version/{type}/{project}/{slug}/{version}"],
+        produces = [MimeTypeUtils.APPLICATION_JSON_VALUE]
+    )
+    fun getGitVersion(
+        @PathVariable("type") type: String,
+        @PathVariable("project") project: String,
+        @PathVariable("slug") slug: String,
+        @PathVariable("version") version: String
+    ): GitVersion {
+        return gitControllerService.getVersion(type, project, slug, version)
+    }
+}

--- a/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/model/Deltas.kt
+++ b/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/model/Deltas.kt
@@ -1,0 +1,12 @@
+package com.amazon.spinnaker.igor.k8s.model
+
+import com.netflix.spinnaker.igor.polling.PollingDelta
+
+data class GitPollingDelta(
+    val deltas: List<GitVersion>,
+    val cachedIds: Set<String>
+) : PollingDelta<GitVersion> {
+    override fun getItems(): MutableList<GitVersion> {
+        return deltas.toMutableList()
+    }
+}

--- a/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/model/GitAccount.kt
+++ b/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/model/GitAccount.kt
@@ -1,0 +1,8 @@
+package com.amazon.spinnaker.igor.k8s.model
+
+data class GitAccount(
+    var name: String = "",
+    var type: String = "",
+    var project: String = "",
+    var url: String = ""
+)

--- a/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/model/GitHubAccount.kt
+++ b/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/model/GitHubAccount.kt
@@ -1,0 +1,9 @@
+package com.amazon.spinnaker.igor.k8s.model
+
+data class GitHubAccount(
+    val name: String,
+    val project: String,
+    val url: String,
+    val account: String? = null,
+    val type: String = "github",
+)

--- a/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/model/GitHubResponse.kt
+++ b/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/model/GitHubResponse.kt
@@ -1,0 +1,38 @@
+package com.amazon.spinnaker.igor.k8s.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class GitHubTagResponse(
+    var name: String = "",
+    var zipball_url: String = "",
+    var tarball_url: String = "",
+    var node_id: String = "",
+    var commit: GitHubCommit = GitHubCommit()
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class GitHubCommit(
+    var sha: String = "",
+    var url: String = ""
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class GitHubCommitResponse(
+    var sha: String = "",
+    var commit: Commit = Commit(),
+    var html_url: String = "",
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class Commit (
+    var author: CommitAuthor = CommitAuthor(),
+    var message: String  = "",
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class CommitAuthor (
+    var name: String = "",
+    var email: String = "",
+    var date: String = ""
+)

--- a/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/model/GitVersion.kt
+++ b/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/model/GitVersion.kt
@@ -1,0 +1,39 @@
+package com.amazon.spinnaker.igor.k8s.model
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.netflix.spinnaker.igor.polling.DeltaItem
+
+data class GitVersion(
+    val name: String,
+    val project: String,
+    val prefix: String,
+    val version: String,
+    val commitId: String,
+    val type: String = "github",
+    var repoUrl: String = "",
+    var url: String? = null,
+    var date: String? = null,
+    var author: String? = null,
+    var message: String? = null,
+    var email: String? = null
+) : DeltaItem {
+    private val id = "git"
+    val uniqueName = "$id-$type-$project-$name"
+
+    override fun toString(): String {
+        return "${prefix}:$id:$type:$project:$name:$version"
+    }
+
+    override fun hashCode(): Int {
+        return toString().hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return other is GitVersion && toString() == other.toString()
+    }
+
+    fun toMap(): Map<String, String> {
+        return jacksonObjectMapper().convertValue(this, object: TypeReference<Map<String, String>>() {})
+    }
+}

--- a/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/monitor/GitHubMonitor.kt
+++ b/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/monitor/GitHubMonitor.kt
@@ -1,0 +1,108 @@
+package com.amazon.spinnaker.igor.k8s.monitor
+
+import com.amazon.spinnaker.igor.k8s.cache.GitCache
+import com.amazon.spinnaker.igor.k8s.config.GitHubAccounts
+import com.amazon.spinnaker.igor.k8s.config.GitHubRestClient
+import com.amazon.spinnaker.igor.k8s.model.GitPollingDelta
+import com.amazon.spinnaker.igor.k8s.model.GitVersion
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.igor.IgorConfigurationProperties
+import com.netflix.spinnaker.igor.history.EchoService
+import com.netflix.spinnaker.igor.keel.KeelService
+import com.netflix.spinnaker.igor.polling.LockService
+import com.netflix.spinnaker.igor.polling.PollContext
+import com.netflix.spinnaker.kork.discovery.DiscoveryStatusListener
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import kotlinx.coroutines.runBlocking
+import org.springframework.scheduling.TaskScheduler
+import java.util.*
+
+class GitHubMonitor(
+    igorProperties: IgorConfigurationProperties?,
+    registry: Registry?,
+    dynamicConfigService: DynamicConfigService?,
+    discoveryStatusListener: DiscoveryStatusListener?,
+    lockService: Optional<LockService>?,
+    scheduler: TaskScheduler?,
+    gitCache: GitCache,
+    echoService: Optional<EchoService>,
+    keelService: Optional<KeelService>,
+    val gitHubRestClient: GitHubRestClient,
+    val gitHubAccounts: GitHubAccounts,
+) : GitMonitor(igorProperties, registry, dynamicConfigService, discoveryStatusListener,
+lockService, scheduler, gitCache, echoService, keelService) {
+
+    override fun getName(): String = "gitHubMonitor"
+
+    override fun poll(sendEvents: Boolean) {
+        log.debug("polling git accounts")
+        gitHubAccounts.accounts.forEach {
+            pollSingle(
+                PollContext(
+                    "${it.project}/${it.name}",
+                    mapOf("name" to it.name, "project" to it.project, "type" to it.type, "repoUrl" to it.url),
+                    !sendEvents
+                )
+            )
+        }
+    }
+
+    override fun generateDelta(ctx: PollContext?): GitPollingDelta {
+        log.debug("getting cached images. context: ${ctx?.context}")
+        val deltas = mutableListOf<GitVersion>()
+        val name = ctx?.context?.get("name") as String
+        val project = ctx.context?.get("project") as String
+        val repoUrl = ctx.context?.get("repoUrl") as String
+
+        val cachedVersion = gitCache.getVersionKeys(ctx.context?.get("type") as String, project, name)
+        log.debug("versions in cache $cachedVersion")
+        val versions = getGitHubTags(name, project)
+        log.debug("versions from remote: $versions")
+        versions.forEach {
+            if (!cachedVersion.contains(it.toString())) {
+                log.debug("$it is not cached. will be cached")
+                deltas.add(
+                    it.copy(repoUrl = repoUrl)
+                )
+            }
+        }
+        log.info("generated ${deltas.size} deltas")
+        log.debug("$deltas")
+        deltas.forEach {
+            val commitInfo = gitHubRestClient.client.getCommit(it.project, it.name, it.commitId)
+            it.url = commitInfo.html_url
+            it.date = commitInfo.commit.author.date
+            it.author = commitInfo.commit.author.name
+            it.message = commitInfo.commit.message
+            it.email = commitInfo.commit.author.email
+        }
+
+        return GitPollingDelta(
+            deltas,
+            cachedVersion.toSet()
+        )
+    }
+
+    override fun generateMetaData(version: GitVersion): Map<String, Any> {
+        return version.toMap()
+    }
+
+    private fun getGitHubTags(name: String, project: String): List<GitVersion> {
+        val results = mutableListOf<GitVersion>()
+        runBlocking {
+            val tags = gitHubRestClient.client.getTags(project, name)
+            tags.forEach {
+                results.add(
+                    GitVersion(
+                        name,
+                        project,
+                        igorProperties.spinnaker.jedis.prefix,
+                        it.name,
+                        it.commit.sha
+                    )
+                )
+            }
+        }
+        return results.toList()
+    }
+}

--- a/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/monitor/GitMonitor.kt
+++ b/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/monitor/GitMonitor.kt
@@ -1,0 +1,91 @@
+package com.amazon.spinnaker.igor.k8s.monitor
+
+import com.amazon.spinnaker.igor.k8s.cache.GitCache
+import com.amazon.spinnaker.igor.k8s.config.GitHubAccounts
+import com.amazon.spinnaker.igor.k8s.config.GitHubRestClient
+import com.amazon.spinnaker.igor.k8s.model.GitPollingDelta
+import com.amazon.spinnaker.igor.k8s.model.GitVersion
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.igor.IgorConfigurationProperties
+import com.netflix.spinnaker.igor.history.EchoService
+import com.netflix.spinnaker.igor.keel.KeelService
+import com.netflix.spinnaker.igor.polling.CommonPollingMonitor
+import com.netflix.spinnaker.igor.polling.LockService
+import com.netflix.spinnaker.igor.polling.PollContext
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import com.netflix.spinnaker.kork.discovery.DiscoveryStatusListener
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.security.AuthenticatedRequest
+import kotlinx.coroutines.runBlocking
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.stereotype.Service
+import java.util.*
+
+abstract class GitMonitor(
+    igorProperties: IgorConfigurationProperties?,
+    registry: Registry?,
+    dynamicConfigService: DynamicConfigService?,
+    discoveryStatusListener: DiscoveryStatusListener?,
+    lockService: Optional<LockService>?,
+    scheduler: TaskScheduler?,
+    val gitCache: GitCache,
+    val echoService: Optional<EchoService>,
+    val keelService: Optional<KeelService>
+) : CommonPollingMonitor<GitVersion, GitPollingDelta>(
+    igorProperties, registry, dynamicConfigService, discoveryStatusListener, lockService, scheduler
+) {
+    abstract override fun getName(): String
+
+    abstract override fun poll(sendEvents: Boolean)
+
+    abstract override fun generateDelta(ctx: PollContext?): GitPollingDelta
+
+    abstract fun generateMetaData(version: GitVersion): Map<String, Any>
+
+    override fun commitDelta(delta: GitPollingDelta?, sendEvents: Boolean) {
+        if (delta?.deltas?.isNotEmpty()!!) {
+            log.debug("caching ${delta.deltas.size} git versions")
+            delta.let {
+                gitCache.cacheVersion(it)
+                log.info("cached $it")
+            }
+            log.debug("cached git versions")
+            if (keelService.isPresent) {
+                delta.deltas.forEach{
+                    postEvent(delta.cachedIds, it)
+                }
+            }
+        }
+    }
+
+    private fun postEvent(cachedVersions: Set<String>, gitVersion: GitVersion) {
+        if (!keelService.isPresent || cachedVersions.isEmpty()) {
+            log.debug("keel service is not enabled or nothing is in cache. Will not send notification.")
+            return
+        }
+
+        val metadata = generateMetaData(gitVersion)
+        val artifact = Artifact.builder()
+            .type("git")
+            .customKind(false)
+            .name(gitVersion.uniqueName)
+            .version(gitVersion.version)
+            .location(gitVersion.uniqueName)
+            .reference(gitVersion.toString())
+            .metadata(metadata)
+            .provenance(gitVersion.uniqueName)
+            .build()
+        val artifactEvent = mapOf(
+            "payload" to mapOf(
+                "artifacts" to listOf(artifact),
+                "details" to emptyMap<String, String>()
+            ),
+            "eventName" to "spinnaker_artifacts_git"
+        )
+        log.debug("sending artifact event to keel")
+        AuthenticatedRequest.allowAnonymous {
+            keelService.get().sendArtifactEvent(artifactEvent)
+        }
+    }
+}

--- a/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/service/GitControllerService.kt
+++ b/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/service/GitControllerService.kt
@@ -1,0 +1,17 @@
+package com.amazon.spinnaker.igor.k8s.service
+
+import com.amazon.spinnaker.igor.k8s.cache.GitCache
+import com.amazon.spinnaker.igor.k8s.model.GitVersion
+
+class GitControllerService(
+    private val gitCache: GitCache
+) {
+
+    fun getVersions(type: String, project: String, name: String): List<GitVersion> {
+        return gitCache.getVersions(type, project, name).toList()
+    }
+
+    fun getVersion(type: String, project: String, name: String, version: String): GitVersion {
+        return gitCache.getVersion(type, project, name, version)
+    }
+}

--- a/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/service/GitHubService.kt
+++ b/k8s-plugin-igor/src/main/kotlin/com/amazon/spinnaker/igor/k8s/service/GitHubService.kt
@@ -1,0 +1,21 @@
+package com.amazon.spinnaker.igor.k8s.service
+
+import com.amazon.spinnaker.igor.k8s.model.GitHubCommitResponse
+import com.amazon.spinnaker.igor.k8s.model.GitHubTagResponse
+import retrofit.http.GET
+import retrofit.http.Path
+
+interface GitHubService {
+    @GET("/repos/{projectKey}/{repositorySlug}/tags")
+    fun getTags(
+        @Path("projectKey") projectKey: String,
+        @Path("repositorySlug") repositorySlug: String
+    ): List<GitHubTagResponse>
+
+    @GET("/repos/{projectKey}/{repositorySlug}/commits/{commitId}")
+    fun getCommit(
+        @Path("projectKey") projectKey: String,
+        @Path("repositorySlug") repositorySlug: String,
+        @Path("commitId") commitId: String
+    ): GitHubCommitResponse
+}

--- a/k8s-plugin-igor/src/test/kotlin/com/amazon/spinnaker/igor/k8s/GitCacheTest.kt
+++ b/k8s-plugin-igor/src/test/kotlin/com/amazon/spinnaker/igor/k8s/GitCacheTest.kt
@@ -1,0 +1,133 @@
+package com.amazon.spinnaker.igor.k8s.cache
+
+import com.amazon.spinnaker.igor.k8s.model.GitVersion
+import com.amazon.spinnaker.igor.k8s.model.GitPollingDelta
+import com.netflix.spinnaker.igor.IgorConfigurationProperties
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
+import io.mockk.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import redis.clients.jedis.commands.JedisCommands
+import redis.clients.jedis.commands.RedisPipeline
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import java.util.function.Consumer
+
+class GitCacheTest {
+    val redisClientDelegate = mockk<RedisClientDelegate>()
+    val igorConfigurationProperties = mockk<IgorConfigurationProperties>()
+    val gitCache = GitCache(
+        redisClientDelegate,
+        igorConfigurationProperties
+    )
+
+    init {
+        every {
+            igorConfigurationProperties.spinnaker.jedis.prefix
+        } returns "igor"
+
+        every {
+            igorConfigurationProperties.spinnaker.pollingSafeguard.itemUpperThreshold
+        } returns 123
+    }
+
+    @AfterEach
+    fun removeMocks() {
+        clearMocks(redisClientDelegate)
+    }
+
+    @Test
+    fun `version keys returned`() {
+        val slot = slot<String>()
+        every {
+            redisClientDelegate.withKeyScan(capture(slot), 1000, any())
+        } just Runs
+
+        gitCache.getVersionKeys("github", "project1", "repo1")
+        verify(exactly = 1) {
+            redisClientDelegate.withKeyScan(capture(slot), 1000, any())
+        }
+        expectThat(slot.captured).isEqualTo("igor:git:github:project1:repo1:*")
+    }
+
+    @Test
+    fun `cached versions returned`() {
+        val jedisCommands = mockk<JedisCommands>()
+        val cachedVersion = mutableMapOf(
+            "name" to "test-repo",
+            "project" to "test-project",
+            "prefix" to "igor",
+            "version" to "1.0.0",
+            "commitId" to "sha123",
+            "type" to "github",
+            "repoUrl" to "some-url",
+            "url" to "some-url",
+            "date" to "some-date",
+            "author" to "author1",
+            "message" to "message1",
+            "email" to "email1"
+        )
+        every {
+            jedisCommands.hgetAll("igor:git:github:test-project:test-repo:1.0.0")
+        } returns cachedVersion
+
+        every {
+            redisClientDelegate.withCommandsClient(any())
+        } answers {
+            val consumer = firstArg<(Consumer<JedisCommands>)>()
+            consumer.accept(jedisCommands)
+        }
+
+        val result =  gitCache.getVersion("github", "test-project", "test-repo", "1.0.0")
+        val returnedMap = result.toMap().toMutableMap()
+        returnedMap.remove("uniqueName")
+
+        expectThat(result.uniqueName).isEqualTo("git-github-test-project-test-repo")
+        expectThat(returnedMap).isEqualTo(cachedVersion)
+    }
+
+    @Test
+    fun `correct versions cached`() {
+        val pipeline = mockk<RedisPipeline>(relaxed = true)
+
+        every {
+            redisClientDelegate.withPipeline(any())
+        } answers {
+            val consumer = firstArg<(Consumer<RedisPipeline>)>()
+            consumer.accept(pipeline)
+        }
+
+        every {
+            redisClientDelegate.syncPipeline(pipeline)
+        } just Runs
+
+        val firstVersion = GitVersion(
+            "repo1",
+            "project1",
+            "igor",
+            "0.0.1",
+            "123",
+        )
+        val secondVersion = GitVersion(
+            "repo1",
+            "project1",
+            "igor",
+            "0.0.2",
+            "123",
+        )
+
+        gitCache.cacheVersion(
+            GitPollingDelta(
+            listOf(firstVersion, secondVersion),
+            emptySet()
+            )
+        )
+
+        verify(exactly = 1) {
+            redisClientDelegate.withPipeline(any())
+            redisClientDelegate.syncPipeline(any())
+            pipeline.hset("igor:git:github:project1:repo1:0.0.1", firstVersion.toMap())
+            pipeline.hset("igor:git:github:project1:repo1:0.0.2", secondVersion.toMap())
+        }
+    }
+}

--- a/k8s-plugin-igor/src/test/kotlin/com/amazon/spinnaker/igor/k8s/GitHubMonitorTest.kt
+++ b/k8s-plugin-igor/src/test/kotlin/com/amazon/spinnaker/igor/k8s/GitHubMonitorTest.kt
@@ -1,0 +1,219 @@
+package com.amazon.spinnaker.igor.k8s.monitor
+
+import com.amazon.spinnaker.igor.k8s.cache.GitCache
+import com.amazon.spinnaker.igor.k8s.config.GitHubAccounts
+import com.amazon.spinnaker.igor.k8s.config.GitHubRestClient
+import com.amazon.spinnaker.igor.k8s.model.*
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spinnaker.igor.IgorConfigurationProperties
+import com.netflix.spinnaker.igor.history.EchoService
+import com.netflix.spinnaker.igor.keel.KeelService
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import io.mockk.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import strikt.assertions.isTrue
+import java.util.*
+
+class GitHubMonitorTest {
+    val igorProperties = mockk<IgorConfigurationProperties>()
+    val gitCache = mockk<GitCache>()
+    val gitHubAccounts = mockk<GitHubAccounts>()
+    val gitHubRestClient = mockk<GitHubRestClient>()
+    val echoService = mockk<EchoService>()
+    val keelService = mockk<KeelService>()
+
+    init {
+           every {
+               igorProperties.spinnaker.jedis.prefix
+           } returns "igor"
+
+            every {
+                igorProperties.spinnaker.pollingSafeguard.itemUpperThreshold
+            } returns 123
+    }
+
+    val gitHubMonitor = GitHubMonitor(
+        igorProperties,
+        DefaultRegistry(),
+        null,
+        null,
+        Optional.empty(),
+        null,
+        gitCache,
+        Optional.of(echoService),
+        Optional.of(keelService),
+        gitHubRestClient,
+        gitHubAccounts
+    )
+
+    @BeforeEach
+    fun setupMocks() {
+        val accounts = mutableListOf(GitHubAccount(
+            name = "test-name",
+            project = "test-project",
+            url = "some-url"
+        ))
+
+        every {
+            gitHubAccounts.accounts
+        } returns accounts
+
+        every {
+            gitCache.getVersionKeys("github", "test-project", "test-name")
+        } returns emptySet()
+
+        every {
+            gitCache.cacheVersion(any())
+        } returns Unit
+
+        every {
+            gitHubRestClient.client.getTags("test-project", "test-name")
+        } returns listOf(
+            GitHubTagResponse(
+                "0.0.1",
+                "",
+                "",
+                "",
+                GitHubCommit("sha123", "some-url")
+            )
+        )
+
+        every {
+            gitHubRestClient.client.getCommit("test-project", "test-name", "sha123")
+        } returns GitHubCommitResponse(
+                sha = "sha123",
+                html_url = "some_url",
+                commit = Commit(
+                    message = "some_message",
+                    author = CommitAuthor(
+                        name = "me",
+                        email = "email",
+                        date = "date"
+                    )
+                )
+        )
+
+        every {
+            keelService.sendArtifactEvent(any())
+        } returns null
+    }
+
+    @AfterEach
+    fun removeMocks() {
+        clearMocks(gitHubAccounts, gitCache, gitHubRestClient)
+    }
+
+    @Test
+    fun `should cache deltas`() {
+        gitHubMonitor.poll(false)
+
+        verify {
+            gitHubRestClient.client.getTags("test-project", "test-name")
+            gitCache.cacheVersion(any())
+            gitCache.getVersionKeys("github", "test-project", "test-name")
+            gitHubAccounts.accounts
+        }
+    }
+
+    @Test
+    fun `should notify keel`() {
+        clearMocks(keelService)
+        val slot = slot<Map<String, Any>>()
+        every {
+            keelService.sendArtifactEvent(capture(slot))
+        } returns null
+
+        every {
+            gitCache.getVersionKeys("github", "test-project", "test-name")
+        } returns setOf("igor:git:github:test-project:test-name:0.0.1")
+
+        every {
+            gitHubRestClient.client.getTags("test-project", "test-name")
+        } returns listOf(
+            GitHubTagResponse(
+                "0.0.2",
+                "",
+                "",
+                "",
+                GitHubCommit("sha123", "some-url")
+            )
+        )
+
+        gitHubMonitor.poll(false)
+
+        verify(exactly = 1) {
+            keelService.sendArtifactEvent(any())
+        }
+        val payload = slot.captured["payload"] as Map<String, Object >
+        val artifacts = payload["artifacts"] as List<Artifact>
+
+        expectThat(artifacts.isNotEmpty()).isTrue()
+        expectThat(artifacts[0].name).isEqualTo("git-github-test-project-test-name")
+    }
+
+    @Test
+    fun `should not cache deltas`() {
+        every {
+            gitCache.getVersionKeys("github", "test-project", "test-name")
+        } returns setOf("igor:git:github:test-project:test-name:0.0.1")
+
+        gitHubMonitor.poll(false)
+
+        verify(exactly = 1) {
+            gitHubRestClient.client.getTags("test-project", "test-name")
+            gitCache.getVersionKeys("github", "test-project", "test-name")
+            gitHubAccounts.accounts
+        }
+        verify(exactly = 0) {
+            gitCache.cacheVersion(any())
+        }
+    }
+
+    @Test
+    fun `should cache deltas when new version is available`() {
+        every {
+            gitCache.getVersionKeys("github", "test-project", "test-name")
+        } returns setOf("igor:git:github:test-project:test-name:0.0.1")
+
+        every {
+            gitHubRestClient.client.getTags("test-project", "test-name")
+        } returns listOf(
+            GitHubTagResponse(
+                "0.0.1",
+                "",
+                "",
+                "",
+                GitHubCommit("sha123", "some-url")
+            ),
+            GitHubTagResponse(
+                "0.0.2",
+                "",
+                "",
+                "",
+                GitHubCommit("sha123", "some-url")
+            )
+        )
+
+        val slot = slot<GitPollingDelta>()
+        every {
+            gitCache.cacheVersion(capture(slot))
+        } returns Unit
+
+        gitHubMonitor.poll(false)
+
+        verify(exactly = 1) {
+            gitCache.getVersionKeys("github", "test-project", "test-name")
+            gitHubAccounts.accounts
+            gitCache.cacheVersion(any())
+        }
+        verify {
+            gitHubRestClient.client.getTags("test-project", "test-name")
+        }
+        expectThat(slot.captured.deltas.size).isEqualTo(1)
+        expectThat(slot.captured.deltas[0].version).isEqualTo("0.0.2")
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
 }
 
 rootProject.name = 'managed-delivery-k8s-plugin'
-include "k8s-plugin", "k8s-plugin-clouddriver", "k8s-plugin-deck"
+include "k8s-plugin", "k8s-plugin-clouddriver", "k8s-plugin-deck", "k8s-plugin-igor"
 
 def setBuildFile(project) {
     project.buildFileName = "${project.name}.gradle"


### PR DESCRIPTION
This allows igor to monitor given git repositories (GitHub only for now). This functionality may need to move to clouddriver in the future, but moving it shouldn't be too difficult.