### PR TITLE
support items field

### DIFF
--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/K8sManifests.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/K8sManifests.kt
@@ -46,6 +46,7 @@ open class K8sManifest(
     open var spec: K8sBlob?,
     open var data: K8sBlob? = null,
     open var status: Status? = null,
+    open var items: MutableList<K8sManifest>? = null
 ) {
     open fun namespace(): String = (metadata[NAMESPACE] ?: NAMESPACE_DEFAULT) as String
     open fun name(): String = throw Exception("not implemented")
@@ -88,6 +89,7 @@ data class K8sObjectManifest(
     override var spec: K8sBlob?,
     override var data: K8sBlob? = null,
     override var status: Status? = null,
+    override var items: MutableList<K8sManifest>? = null
 ) : K8sManifest(apiVersion, kind, metadata, spec, data, status) {
     override fun name(): String = metadata[NAME] as String
 }

--- a/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/K8sManifests.kt
+++ b/k8s-plugin/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/K8sManifests.kt
@@ -46,6 +46,7 @@ open class K8sManifest(
     open var spec: K8sBlob?,
     open var data: K8sBlob? = null,
     open var status: Status? = null,
+    // TODO do we want to fully support this?
     open var items: MutableList<K8sManifest>? = null
 ) {
     open fun namespace(): String = (metadata[NAMESPACE] ?: NAMESPACE_DEFAULT) as String

--- a/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/K8sResourceHandlerTest.kt
+++ b/k8s-plugin/src/test/kotlin/com/amazon/spinnaker/keel/tests/K8sResourceHandlerTest.kt
@@ -604,8 +604,9 @@ internal class K8sResourceHandlerTest : JUnit5Minutests {
                 runBlocking {
                     val spec = desired(currentSpec)
                     expectThat(spec.items?.size).isEqualTo(2)
-                    spec.items?.map {
+                    spec.items?.forEach {
                         val labels = it.metadata[LABELS] as MutableMap<String, String>
+                        // ensure existing label is preserved for the Service kind
                         if (it.kind == "Service") {
                             expectThat(labels).hasEntry("labelKey", "labelValue")
                         }


### PR DESCRIPTION
Adds very basic deployment support for items property. Mainly meant to be used by the kustomize handler. 

In the future, we need to add support for getting resources created with `List` kind from K8s cluster.