### PR TITLE
add license check github action

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,27 @@
+name: Check license
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Golang
+      uses: actions/setup-go@v2
+    - name: Install addlicense
+      run: |
+        export PATH=${PATH}:`go env GOPATH`/bin
+        go get -v -u github.com/google/addlicense
+    - name: Check license
+      run: |
+        export PATH=${PATH}:`go env GOPATH`/bin
+        addlicense -check -l apache -c "Amazon.com, Inc." $(find $PWD -type f -name "*.kt" -o -name "*.ts")
+

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,12 +1,6 @@
 name: Check license
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: [ pull_request ]
 
 jobs:
   build:


### PR DESCRIPTION
this fails PR if license header is not included in any of `.kt` or `.ts` files. 
Uses: https://github.com/google/addlicense 
