### PR TITLE
require go verion 1.17+

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -3,13 +3,14 @@ name: Check license
 on: [ pull_request ]
 
 jobs:
-  build:
+  licenseCheck:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Golang
       uses: actions/setup-go@v2
+      with:
+        go-version: '^1.17'
     - name: Install addlicense
       run: |
         export PATH=${PATH}:`go env GOPATH`/bin


### PR DESCRIPTION
For some reason the `actions/setup-go@v2` started to pull an ancient version of go without the io/fs package. It now requires go 1.17+. 