### PR TITLE
support null artifact spec

### DIFF
--- a/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/BaseFluxResourceSpec.kt
+++ b/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/BaseFluxResourceSpec.kt
@@ -19,10 +19,10 @@ import com.netflix.spinnaker.keel.api.ArtifactReferenceProvider
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 
 abstract class BaseFluxResourceSpec:  ArtifactReferenceProvider, GenericK8sLocatable {
-    abstract val artifactSpec: ArtifactSpec
+    abstract val artifactSpec: ArtifactSpec?
 
     override val artifactReference: String
-        get() = artifactSpec.ref
+        get() = artifactSpec?.ref ?: "none-specified"
 
     override val artifactType: ArtifactType
         get() = FluxSupportedSourceType.GIT.name.toLowerCase()

--- a/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/BaseFluxResourceSpec.kt
+++ b/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/BaseFluxResourceSpec.kt
@@ -14,18 +14,13 @@
 
 package com.amazon.spinnaker.keel.k8s.model
 
-import com.amazon.spinnaker.keel.k8s.FluxSupportedSourceType
 import com.netflix.spinnaker.keel.api.ArtifactReferenceProvider
-import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 
 abstract class BaseFluxResourceSpec:  ArtifactReferenceProvider, GenericK8sLocatable {
     abstract val artifactSpec: ArtifactSpec?
 
-    override val artifactReference: String
-        get() = artifactSpec?.ref ?: "none-specified"
-
-    override val artifactType: ArtifactType
-        get() = FluxSupportedSourceType.GIT.name.toLowerCase()
+    override val artifactReference: String?
+        get() = artifactSpec?.ref
 }
 
 // allow overriding things specified in BaseFluxArtifact per resource

--- a/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/HelmResourceSpec.kt
+++ b/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/HelmResourceSpec.kt
@@ -15,17 +15,19 @@
 package com.amazon.spinnaker.keel.k8s.model
 
 import com.amazon.spinnaker.keel.k8s.*
-import com.netflix.spinnaker.keel.api.ArtifactReferenceProvider
 import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
-import com.netflix.spinnaker.keel.docker.ReferenceProvider
 
 class HelmResourceSpec (
     override val metadata: Map<String, String>,
     override var template: K8sObjectManifest,
     override val locations: SimpleLocations,
     override val artifactSpec: ArtifactSpec?
-): ArtifactReferenceProvider, BaseFluxResourceSpec() {
+): BaseFluxResourceSpec() {
+    // This needs to be re-visited when another flux artifact type is introduced.
+    override val artifactType: ArtifactType
+        get() = FluxSupportedSourceType.GIT.name.toLowerCase()
+
     init {
         template.kind = template.kind ?: FLUX_HELM_KIND
         template.apiVersion = template.apiVersion ?: FLUX_HELM_API_VERSION

--- a/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/HelmResourceSpec.kt
+++ b/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/HelmResourceSpec.kt
@@ -21,11 +21,10 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.docker.ReferenceProvider
 
 class HelmResourceSpec (
-    val chart: ReferenceProvider? = null,
     override val metadata: Map<String, String>,
     override var template: K8sObjectManifest,
     override val locations: SimpleLocations,
-    override val artifactSpec: ArtifactSpec
+    override val artifactSpec: ArtifactSpec?
 ): ArtifactReferenceProvider, BaseFluxResourceSpec() {
     init {
         template.kind = template.kind ?: FLUX_HELM_KIND

--- a/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/KustomizeResourceSpec.kt
+++ b/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/KustomizeResourceSpec.kt
@@ -23,7 +23,7 @@ class KustomizeResourceSpec (
     override val metadata: Map<String, String>,
     override var template: K8sObjectManifest,
     override val locations: SimpleLocations,
-    override val artifactSpec: ArtifactSpec
+    override val artifactSpec: ArtifactSpec?
 ): BaseFluxResourceSpec(), GenericK8sLocatable {
     init {
         template.kind = template.kind ?: FLUX_KUSTOMIZE_KIND

--- a/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/KustomizeResourceSpec.kt
+++ b/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/model/KustomizeResourceSpec.kt
@@ -15,7 +15,6 @@
 package com.amazon.spinnaker.keel.k8s.model
 
 import com.amazon.spinnaker.keel.k8s.*
-import com.netflix.spinnaker.keel.api.ArtifactReferenceProvider
 import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 
@@ -25,6 +24,9 @@ class KustomizeResourceSpec (
     override val locations: SimpleLocations,
     override val artifactSpec: ArtifactSpec?
 ): BaseFluxResourceSpec(), GenericK8sLocatable {
+    override val artifactType: ArtifactType
+        get() = FluxSupportedSourceType.GIT.name.toLowerCase()
+
     init {
         template.kind = template.kind ?: FLUX_KUSTOMIZE_KIND
         template.apiVersion = template.apiVersion ?: FLUX_KUSTOMIZE_API_VERSION

--- a/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/BaseFluxHandler.kt
+++ b/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/BaseFluxHandler.kt
@@ -59,7 +59,7 @@ abstract class BaseFluxHandler<S : BaseFluxResourceSpec, R : K8sManifest>(
         val environment = repository.environmentFor(r.id)
         if (r.spec.artifactSpec != null) {
             val (artifact, _) = getArtifactAndConfig(r)
-            requireNotNull(artifact) {"artifact could not be found in delivery config (null)"} // this shouldn't happen (famous last word)
+            requireNotNull(artifact) { "artifact could not be found in delivery config (null) resource: $r" } // this shouldn't happen (famous last word)
             val resolvedArtifact = resolveArtifactSpec(r, artifact)
             return getFluxK8sResources(r, resolvedArtifact, generateCorrelationId(r), environment.name)
         }
@@ -260,7 +260,7 @@ abstract class BaseFluxHandler<S : BaseFluxResourceSpec, R : K8sManifest>(
         }
     }
 
-    private suspend fun getFluxK8sResource( resource: Resource<S>, correlationId: String): R? {
+    private suspend fun getFluxK8sResource(resource: Resource<S>, correlationId: String): R? {
         try {
             return coroutineScope {
                 return@coroutineScope toK8sList(null, getFluxResourceManifest(resource), correlationId)

--- a/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/BaseFluxHandler.kt
+++ b/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/BaseFluxHandler.kt
@@ -55,19 +55,16 @@ abstract class BaseFluxHandler<S : BaseFluxResourceSpec, R : K8sManifest>(
         return deployed
     }
 
-
     override suspend fun getK8sResource(r: Resource<S>): R? {
         val environment = repository.environmentFor(r.id)
-        val (artifact, _) = getArtifactAndConfig(r)
-        when (artifact) {
-            is GitRepoArtifact -> {
-                val resolvedArtifact = resolveArtifactSpec(r, artifact)
-                return getFluxK8sResources(r, resolvedArtifact, generateCorrelationId(r), environment.name)
-            }
-            else -> {
-                throw InvalidArtifact("artifact is not a supported artifact type. artifact: $artifact")
-            }
+        if (r.spec.artifactSpec != null) {
+            val (artifact, _) = getArtifactAndConfig(r)
+            requireNotNull(artifact) {"artifact could not be found in delivery config (null)"} // this shouldn't happen (famous last word)
+            val resolvedArtifact = resolveArtifactSpec(r, artifact)
+            return getFluxK8sResources(r, resolvedArtifact, generateCorrelationId(r), environment.name)
         }
+        // without artifact reference
+        return getFluxK8sResource(r, generateCorrelationId(r))
     }
 
     override suspend fun actuationInProgress(resource: Resource<S>): Boolean =
@@ -92,54 +89,62 @@ abstract class BaseFluxHandler<S : BaseFluxResourceSpec, R : K8sManifest>(
         return super.upsert(resource, diff)
     }
 
-    @Suppress("UNCHECKED_CAST")
-    suspend fun getFluxK8sResources(
+    private suspend fun getFluxResourceManifest(
+        resource: Resource<S>
+    ): R {
+        return coroutineScope {
+            val resourceJob = async {
+                cloudDriverK8sService.getK8sResource(
+                    resource.serviceAccount,
+                    resource.spec.locations.account,
+                    getNamespace(resource),
+                    resource.spec.template!!.kindQualifiedName()
+                )
+            }
+            val resourceResponse = resourceJob.await()
+            return@coroutineScope parseFluxResourceManifest(resourceResponse)
+        }
+    }
+
+    private suspend fun getFluxRepoManifest(
+        resource: Resource<S>,
+        artifact: BaseFluxArtifact,
+        environment: String?
+    ): R {
+        val repoNamespace: String = artifact.namespace
+        val repoNameInClouddriver: String = environment?.let {
+            "${artifact.kind} ${artifact.name}-$it"
+        } ?: "${artifact.kind} ${artifact.name}"
+        return coroutineScope {
+            val repoJob = async {
+                cloudDriverK8sService.getK8sResource(
+                    resource.serviceAccount,
+                    resource.spec.locations.account,
+                    repoNamespace,
+                    repoNameInClouddriver
+                )
+            }
+            val repoResponse = repoJob.await()
+            return@coroutineScope parseFluxResourceManifest(repoResponse)
+        }
+    }
+
+    private suspend fun getFluxK8sResources(
         resource: Resource<S>,
         artifact: BaseFluxArtifact,
         correlationId: String,
         environment: String?
     ): R? {
-        val namespace = getNamespace(resource)
-        val repoNamespace: String = artifact.namespace
-        val repoNameInClouddriver: String = environment?.let {
-            "${artifact.kind} ${artifact.name}-$it"
-        } ?: run { "${artifact.kind} ${artifact.name}" }
-
         // need to wrap async with coroutineScope to catch exceptions correctly
         try {
             return coroutineScope {
                 val repoJob = async {
-                    cloudDriverK8sService.getK8sResource(
-                        resource.serviceAccount,
-                        resource.spec.locations.account,
-                        repoNamespace,
-                        repoNameInClouddriver
-                    )
+                    getFluxRepoManifest(resource, artifact, environment)
                 }
                 val resourceJob = async {
-                    cloudDriverK8sService.getK8sResource(
-                        resource.serviceAccount,
-                        resource.spec.locations.account,
-                        namespace,
-                        resource.spec.template!!.kindQualifiedName()
-                    )
+                    getFluxResourceManifest(resource)
                 }
-                val repoResponse = repoJob.await()
-                val resourceResponse = resourceJob.await()
-
-                val lastAppliedConfigRepo =
-                    (repoResponse.manifest.to<K8sObjectManifest>().metadata[ANNOTATIONS] as Map<String, String>)[K8S_LAST_APPLIED_CONFIG] as String
-                val repoManifest = cleanup(mapper.readValue<K8sObjectManifest>(lastAppliedConfigRepo) as R)
-
-                val lastAppliedConfigResource =
-                    (resourceResponse.manifest.to<K8sObjectManifest>().metadata[ANNOTATIONS] as Map<String, String>)[K8S_LAST_APPLIED_CONFIG] as String
-                val resourceManifest = cleanup(mapper.readValue<K8sObjectManifest>(lastAppliedConfigResource) as R)
-
-                if (repoManifest == null || resourceManifest == null) {
-                    log.error("unable to read last applied config from clouddriver.")
-                    throw ClouddriverProcessingError("unable to read last applied config from clouddriver.")
-                }
-                return@coroutineScope toK8sList(repoManifest, resourceManifest, correlationId)
+                return@coroutineScope toK8sList(repoJob.await(), resourceJob.await(), correlationId)
             }
         } catch (e: HttpException) {
             if (e.code() == 404) {
@@ -165,7 +170,7 @@ abstract class BaseFluxHandler<S : BaseFluxResourceSpec, R : K8sManifest>(
 
     @Suppress("UNCHECKED_CAST")
     fun toK8sList(
-        repoManifest: R,
+        repoManifest: R?,
         resourceManifest: R,
         name: String
     ): R {
@@ -178,10 +183,10 @@ abstract class BaseFluxHandler<S : BaseFluxResourceSpec, R : K8sManifest>(
             null,
             null,
             null,
-            mutableListOf(
+            listOfNotNull(
                 repoManifest,
                 resourceManifest
-            )
+            ).toMutableList()
         ) as R
     }
 
@@ -210,29 +215,29 @@ abstract class BaseFluxHandler<S : BaseFluxResourceSpec, R : K8sManifest>(
         }
     }
 
-    fun getArtifactAndConfig(resource: Resource<S>): Pair<BaseFluxArtifact, DeliveryConfig> {
+    fun getArtifactAndConfig(resource: Resource<S>): Pair<BaseFluxArtifact?, DeliveryConfig> {
         val deliveryConfig = repository.deliveryConfigFor(resource.id)
-        resource.spec.artifactReference.let { artifactRef ->
-            val artifact = deliveryConfig.artifacts.find {
-                log.trace("checking $it")
-                it.reference == artifactRef
+        val artifact = resource.spec.artifactSpec?.let { artifactSpec ->
+            val artifactInConfig = deliveryConfig.artifacts.find {
+                log.debug("checking $it")
+                it.reference == artifactSpec.ref
             } ?: throw NoMatchingArtifactException(
                 deliveryConfigName = deliveryConfig.name,
                 type = "unknown",
-                reference = artifactRef
+                reference = artifactSpec.ref
             )
-
-            log.debug("found FluxArtifact: $artifact")
-            return Pair(artifact as BaseFluxArtifact, deliveryConfig)
+            artifactInConfig as BaseFluxArtifact
         }
+        log.debug("Flux artifact in delivery config: $artifact")
+        return Pair(artifact, deliveryConfig)
     }
 
     inline fun <reified T : BaseFluxArtifact> resolveArtifactSpec(resource: Resource<S>, artifact: T): T {
         when (artifact) {
             is GitRepoArtifact -> {
                 return artifact.copy(
-                    namespace = resource.spec.artifactSpec.namespace ?: artifact.namespace,
-                    interval = resource.spec.artifactSpec.interval ?: artifact.interval
+                    namespace = resource.spec.artifactSpec?.namespace ?: artifact.namespace,
+                    interval = resource.spec.artifactSpec?.interval ?: artifact.interval
                 ) as T
             }
             // TODO add support for more artifacts
@@ -253,5 +258,33 @@ abstract class BaseFluxHandler<S : BaseFluxResourceSpec, R : K8sManifest>(
             log.info("Deploying Git artifact $it")
             notifyArtifactDeploying(resource, it)
         }
+    }
+
+    private suspend fun getFluxK8sResource( resource: Resource<S>, correlationId: String): R? {
+        try {
+            return coroutineScope {
+                return@coroutineScope toK8sList(null, getFluxResourceManifest(resource), correlationId)
+            }
+        } catch (e: HttpException) {
+            if (e.code() == 404) {
+                log.info("resource ${resource.id} not found")
+                return null
+            } else {
+                throw e
+            }
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun parseFluxResourceManifest(response: K8sResourceModel): R {
+        val lastAppliedConfigResource =
+            (response.manifest.to<K8sObjectManifest>().metadata[ANNOTATIONS] as Map<String, String>)[K8S_LAST_APPLIED_CONFIG] as String
+        val resourceManifest = cleanup(mapper.readValue<K8sObjectManifest>(lastAppliedConfigResource) as R)
+
+        if (resourceManifest == null) {
+            log.error("unable to read last applied config from clouddriver.")
+            throw ClouddriverProcessingError("unable to read last applied config from clouddriver.")
+        }
+        return resourceManifest
     }
 }

--- a/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/HelmResourceHandler.kt
+++ b/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/resolver/HelmResourceHandler.kt
@@ -45,15 +45,17 @@ class HelmResourceHandler(
 
     @Suppress("UNCHECKED_CAST")
     public override suspend fun toResolvedType(resource: Resource<HelmResourceSpec>): K8sObjectManifest {
+        log.debug("resolving helm resource definition")
         verifyChartResource(resource)
         val (artifact, deliveryConfig) = getArtifactAndConfig(resource)
         if (artifact == null) {
+            log.debug("artifact reference is null. returning supplied template as is")
             resource.spec.template = toK8sList(
                 null, resource.spec.template, generateCorrelationId(resource)
             )
             return super.toResolvedType(resource)
         }
-
+        log.debug("applying artifact to this helm resource")
         val environment = repository.environmentFor(resource.id)
         val version = repository.latestVersionApprovedIn(
             deliveryConfig, artifact, environment.name
@@ -63,6 +65,7 @@ class HelmResourceHandler(
             // flux ignores the version field when GitRepository or Bucket is used. Must specify version at source controller
             is GitRepoArtifact -> {
                 val resolvedArtifact = resolveArtifactSpec(resource, artifact)
+                log.debug("applied resource specific override to git artifact. artifact: $artifact")
                 val sourceRef = mutableMapOf(
                     NAME to "${resolvedArtifact.name}-${environment.name}",
                     KIND to resolvedArtifact.kind,

--- a/k8s-plugin-keel/src/test/kotlin/com/amazon/spinnaker/keel/tests/HelmResourceHandlerTest.kt
+++ b/k8s-plugin-keel/src/test/kotlin/com/amazon/spinnaker/keel/tests/HelmResourceHandlerTest.kt
@@ -80,8 +80,10 @@ internal class HelmResourceHandlerTest : JUnit5Minutests {
     fun tests() = rootContext<HelmResourceHandler> {
         val helmResourceYaml = this::class.java.classLoader.getResource("helm/helmResource.yml").readText()
         val deliveryConfigYaml = this::class.java.classLoader.getResource("helm/deliveryConfig.yml").readText()
-        val clouddvierGitRepoYaml = this::class.java.classLoader.getResource("helm/clouddriverGitRepoResponse.yml").readText()
-        val deliveryConfigWithoutArtifactYaml = this::class.java.classLoader.getResource("helm/deliveryConfigWithoutArtifact.yml").readText()
+        val clouddvierGitRepoYaml =
+            this::class.java.classLoader.getResource("helm/clouddriverGitRepoResponse.yml").readText()
+        val deliveryConfigWithoutArtifactYaml =
+            this::class.java.classLoader.getResource("helm/deliveryConfigWithoutArtifact.yml").readText()
 
         val deliveryConfig =
             yamlMapper.readValue(deliveryConfigYaml, SubmittedDeliveryConfig::class.java).makeDeliveryConfig()
@@ -99,7 +101,7 @@ internal class HelmResourceHandlerTest : JUnit5Minutests {
 
         context("resource verification") {
             test("missing spec results in error") {
-                val badSpec =  yamlMapper.readValue(helmResourceYaml, HelmResourceSpec::class.java)
+                val badSpec = yamlMapper.readValue(helmResourceYaml, HelmResourceSpec::class.java)
                 badSpec.template.spec = null
                 expectCatching {
                     toResolvedType(
@@ -112,7 +114,7 @@ internal class HelmResourceHandlerTest : JUnit5Minutests {
             }
 
             test("missing template.spec.chart field results in error") {
-                val badSpec =  yamlMapper.readValue(helmResourceYaml, HelmResourceSpec::class.java)
+                val badSpec = yamlMapper.readValue(helmResourceYaml, HelmResourceSpec::class.java)
                 badSpec.template.spec!!.remove("chart")
                 expectCatching {
                     toResolvedType(
@@ -124,7 +126,7 @@ internal class HelmResourceHandlerTest : JUnit5Minutests {
                 }.failed().isA<CannotResolveDesiredState>()
             }
             test("missing template.spec.chart.spec field results in error") {
-                val badSpec =  yamlMapper.readValue(helmResourceYaml, HelmResourceSpec::class.java)
+                val badSpec = yamlMapper.readValue(helmResourceYaml, HelmResourceSpec::class.java)
                 (badSpec.template.spec!!["chart"] as MutableMap<String, Any>).remove("spec")
                 expectCatching {
                     toResolvedType(
@@ -136,8 +138,10 @@ internal class HelmResourceHandlerTest : JUnit5Minutests {
                 }.failed().isA<CannotResolveDesiredState>()
             }
             test("missing template.spec.chart.spec.chart field results in error") {
-                val badSpec =  yamlMapper.readValue(helmResourceYaml, HelmResourceSpec::class.java)
-                ((badSpec.template.spec!!["chart"] as MutableMap<String, Any>)["spec"] as MutableMap<String, String>).remove("chart")
+                val badSpec = yamlMapper.readValue(helmResourceYaml, HelmResourceSpec::class.java)
+                ((badSpec.template.spec!!["chart"] as MutableMap<String, Any>)["spec"] as MutableMap<String, String>).remove(
+                    "chart"
+                )
                 expectCatching {
                     toResolvedType(
                         resource(
@@ -351,8 +355,11 @@ internal class HelmResourceHandlerTest : JUnit5Minutests {
         }
 
         context("spec without artifact") {
-            val deliveryConfigWithoutArtifact = yamlMapper.readValue(deliveryConfigWithoutArtifactYaml, SubmittedDeliveryConfig::class.java).makeDeliveryConfig()
-            val helmResourceWithoutArtifactYaml = this::class.java.classLoader.getResource("helm/helmResourceWithoutArtifact.yml").readText()
+            val deliveryConfigWithoutArtifact =
+                yamlMapper.readValue(deliveryConfigWithoutArtifactYaml, SubmittedDeliveryConfig::class.java)
+                    .makeDeliveryConfig()
+            val helmResourceWithoutArtifactYaml =
+                this::class.java.classLoader.getResource("helm/helmResourceWithoutArtifact.yml").readText()
 
             before {
                 coEvery {
@@ -369,7 +376,7 @@ internal class HelmResourceHandlerTest : JUnit5Minutests {
                 runBlocking {
                     val resolved = toResolvedType(resource)
                     expectThat(resolved.items?.size).isEqualTo(1)
-                    resolved.items?.first()?.let{
+                    resolved.items?.first()?.let {
                         expectThat(it.apiVersion).isEqualTo(FLUX_HELM_API_VERSION)
                         expectThat(it.kind).isEqualTo(FLUX_HELM_KIND)
                     }
@@ -432,7 +439,8 @@ internal class HelmResourceHandlerTest : JUnit5Minutests {
     }
 
     private fun helmResourceModel(path: String? = null): K8sResourceModel {
-        val clouddriverHelmYaml = this::class.java.classLoader.getResource(path ?: "helm/clouddriverHelmResponse.yml").readText()
+        val clouddriverHelmYaml =
+            this::class.java.classLoader.getResource(path ?: "helm/clouddriverHelmResponse.yml").readText()
         val lastApplied = yamlMapper.readValue(clouddriverHelmYaml, HelmResourceSpec::class.java)
         return K8sResourceModel(
             account = "my-k8s-west-account",

--- a/k8s-plugin-keel/src/test/kotlin/com/amazon/spinnaker/keel/tests/HelmResourceSpecTest.kt
+++ b/k8s-plugin-keel/src/test/kotlin/com/amazon/spinnaker/keel/tests/HelmResourceSpecTest.kt
@@ -15,7 +15,6 @@
 package com.amazon.spinnaker.keel.tests
 
 import com.amazon.spinnaker.keel.k8s.model.HelmResourceSpec
-import com.amazon.spinnaker.keel.k8s.model.K8sResourceSpec
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
@@ -23,6 +22,7 @@ import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
+import strikt.assertions.isNull
 
 internal object HelmResourceSpecTest : JUnit5Minutests {
 
@@ -74,6 +74,44 @@ internal object HelmResourceSpecTest : JUnit5Minutests {
                 test("stores correct application metadata from the spec") {
                     expectThat(this)
                         .get { metadata["application"] }.isEqualTo("fnord")
+                }
+
+                test("artifact ref stored correctly") {
+                    expectThat(this)
+                        .get { artifactReference }.isEqualTo("my-git-artifact")
+                }
+            }
+        }
+        context("a simple Helm resource definition without artifact ref") {
+            fixture {
+                Fixture(
+                    yaml = """
+                        |---
+                        |locations:
+                        |  account: my-k8s-west-account
+                        |  regions: []
+                        |metadata:
+                        |  application: fnord
+                        |template:
+                        |  apiVersion: source.toolkit.fluxcd.io/v1beta1
+                        |  kind: HelmRepository
+                        |  metadata:
+                        |      name: crossplane-master
+                        |  spec:
+                        |      interval: 5m
+                        |      url: https://charts.crossplane.io/master
+                    """.trimMargin()
+                )
+            }
+
+            derivedContext<HelmResourceSpec>("when deserialized") {
+                deriveFixture {
+                    mapper.readValue(yaml)
+                }
+
+                test("null artifact ref returned") {
+                    expectThat(this)
+                        .get { artifactReference }.isNull()
                 }
             }
         }

--- a/k8s-plugin-keel/src/test/kotlin/com/amazon/spinnaker/keel/tests/HelmResourceSpecTest.kt
+++ b/k8s-plugin-keel/src/test/kotlin/com/amazon/spinnaker/keel/tests/HelmResourceSpecTest.kt
@@ -37,8 +37,6 @@ internal object HelmResourceSpecTest : JUnit5Minutests {
                 Fixture(
                     yaml = """
                         |---
-                        |chart:
-                        |  reference: something
                         |locations:
                         |  account: my-k8s-west-account
                         |  regions: []
@@ -76,11 +74,6 @@ internal object HelmResourceSpecTest : JUnit5Minutests {
                 test("stores correct application metadata from the spec") {
                     expectThat(this)
                         .get { metadata["application"] }.isEqualTo("fnord")
-                }
-
-                test("has chart information properly stored") {
-                    expectThat(this)
-                        .get { chart?.reference }.isEqualTo("something")
                 }
             }
         }

--- a/k8s-plugin-keel/src/test/resources/helm/clouddriverGitRepoResponse.yml
+++ b/k8s-plugin-keel/src/test/resources/helm/clouddriverGitRepoResponse.yml
@@ -1,0 +1,25 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  annotations:
+    artifact.spinnaker.io/location: flux-system
+    artifact.spinnaker.io/name: git-github-testProject-testRepo
+    artifact.spinnaker.io/type: kubernetes/GitRepository.source.toolkit.fluxcd.io
+    artifact.spinnaker.io/version: ''
+    moniker.spinnaker.io/application: keeldemo
+    moniker.spinnaker.io/cluster: >-
+      GitRepository.source.toolkit.fluxcd.io
+      git-github-testProject-testRepo
+  labels:
+    app.kubernetes.io/managed-by: spinnaker
+    app.kubernetes.io/name: keeldemo
+    md.spinnaker.io/plugin: k8s
+  name: git-github-testProject-testRepo-testEnv
+  namespace: flux-system
+spec:
+  interval: 1m
+  ref:
+    tag: 1.0.0
+  secretRef:
+    name: git-repo
+  url: https://repo.url

--- a/k8s-plugin-keel/src/test/resources/helm/clouddriverHelmResponse.yml
+++ b/k8s-plugin-keel/src/test/resources/helm/clouddriverHelmResponse.yml
@@ -1,0 +1,34 @@
+locations:
+  account: my-k8s-west-account
+  regions: []
+metadata:
+  application: fnord
+artifactSpec:
+  ref: my-git-artifact
+template:
+  apiVersion: helm.toolkit.fluxcd.io/v2beta1
+  kind: HelmRelease
+  metadata:
+    annotations:
+      artifact.spinnaker.io/name: git-github-testProject-testRepo
+      artifact.spinnaker.io/location: flux-system
+      moniker.spinnaker.io/application: keeldemo
+    name: fnord-test
+    namespace: flux-system
+    application: fnord
+    labels:
+      md.spinnaker.io/plugin: k8s
+  spec:
+    releaseName: crossplane
+    targetNamespace: crossplane-system
+    chart:
+      spec:
+        chart: crossplane
+        sourceRef:
+          name: git-github-testProject-testRepo-testEnv
+          kind: GitRepository
+          namespace: flux-system
+    interval: 1m
+    install:
+      remediation:
+       retries: 3

--- a/k8s-plugin-keel/src/test/resources/helm/clouddriverHelmResponseWithoutArtifact.yml
+++ b/k8s-plugin-keel/src/test/resources/helm/clouddriverHelmResponseWithoutArtifact.yml
@@ -1,0 +1,35 @@
+locations:
+  account: my-k8s-west-account
+  regions: []
+metadata:
+  application: fnord
+artifactSpec:
+  ref: my-git-artifact
+template:
+  apiVersion: helm.toolkit.fluxcd.io/v2beta1
+  kind: HelmRelease
+  metadata:
+    annotations:
+      artifact.spinnaker.io/name: git-github-testProject-testRepo
+      artifact.spinnaker.io/location: flux-system
+      moniker.spinnaker.io/application: keeldemo
+    name: fnord-test
+    namespace: flux-system
+    application: fnord
+    labels:
+      md.spinnaker.io/plugin: k8s
+  spec:
+    releaseName: crossplane
+    targetNamespace: crossplane-system
+    chart:
+      spec:
+        chart: crossplane
+        version: "0.0.1"
+        sourceRef:
+          name: testSource
+          kind: HelmRepository
+          namespace: flux-system
+    interval: 1m
+    install:
+      remediation:
+       retries: 3

--- a/k8s-plugin-keel/src/test/resources/helm/deliveryConfig.yml
+++ b/k8s-plugin-keel/src/test/resources/helm/deliveryConfig.yml
@@ -1,0 +1,37 @@
+name: demo1
+application: fnord
+serviceAccount: keeltest-service-account
+artifacts:
+  - type: git
+    reference: my-git-artifact
+    tagVersionStrategy: semver-tag
+    repoName: testRepo
+    project: testProject
+    gitType: github
+    secretRef: git-repo
+environments:
+  - name: test
+    locations:
+      account: deploy-experiments
+      regions: []
+    resources:
+      - kind: k8s/helm@v1
+        spec:
+          artifactSpec:
+            ref: my-git-artifact
+          metadata:
+            application: fnord
+          template:
+            metadata:
+              name: crossplane
+              namespace: flux-system
+            spec:
+              releaseName: crossplane
+              targetNamespace: crossplane-system
+              chart:
+                spec:
+                  chart: crossplane
+              interval: 1m
+              install:
+                remediation:
+                  retries: 3

--- a/k8s-plugin-keel/src/test/resources/helm/deliveryConfigWithoutArtifact.yml
+++ b/k8s-plugin-keel/src/test/resources/helm/deliveryConfigWithoutArtifact.yml
@@ -1,0 +1,33 @@
+name: demo1
+application: fnord
+serviceAccount: keeltest-service-account
+artifacts: []
+environments:
+  - name: test
+    locations:
+      account: deploy-experiments
+      regions: []
+    resources:
+      - kind: k8s/helm@v1
+        spec:
+          metadata:
+            application: fnord
+          template:
+            metadata:
+              name: crossplane
+              namespace: flux-system
+            spec:
+              releaseName: crossplane
+              targetNamespace: crossplane-system
+              chart:
+                spec:
+                  chart: crossplane
+                  version: "0.0.1"
+                  sourceRef:
+                    kind: HelmRepository
+                    name: testSource
+                    namespace: flux-system
+              interval: 1m
+              install:
+                remediation:
+                  retries: 3

--- a/k8s-plugin-keel/src/test/resources/helm/helmResource.yml
+++ b/k8s-plugin-keel/src/test/resources/helm/helmResource.yml
@@ -1,0 +1,22 @@
+locations:
+  account: my-k8s-west-account
+  regions: []
+metadata:
+  application: fnord
+artifactSpec:
+  ref: my-git-artifact
+template:
+  metadata:
+    name: fnord-test
+    namespace: flux-system
+    application: fnord
+  spec:
+    releaseName: crossplane
+    targetNamespace: crossplane-system
+    chart:
+      spec:
+        chart: crossplane
+    interval: 1m
+    install:
+      remediation:
+        retries: 3

--- a/k8s-plugin-keel/src/test/resources/helm/helmResourceWithoutArtifact.yml
+++ b/k8s-plugin-keel/src/test/resources/helm/helmResourceWithoutArtifact.yml
@@ -1,0 +1,25 @@
+locations:
+  account: my-k8s-west-account
+  regions: []
+metadata:
+  application: fnord
+template:
+  metadata:
+    name: fnord-test
+    namespace: flux-system
+    application: fnord
+  spec:
+    releaseName: crossplane
+    targetNamespace: crossplane-system
+    chart:
+      spec:
+        chart: crossplane
+        version: "0.0.1"
+        sourceRef:
+          kind: HelmRepository
+          name: testSource
+          namespace: flux-system
+    interval: 1m
+    install:
+      remediation:
+        retries: 3


### PR DESCRIPTION
`resource.spec.artifactSpec` is no longer required. 

Separated calls to clouddriver to get repo and flux resource into their own methods for reuse when artifact spec is not defined.

Moved  helm test yaml strings to resrouce yaml files since there were so many of them. 

fixes #82 