### PR TITLE
keel 0.197.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 |  <= 0.0.6   |  0.191.1 |
 |  0.0.7      |  0.194.1 |
 |  0.0.8 <=   |  0.195.0 |
+|  0.0.10     |  0.197.0 |
 
 It is also recommended to use Spinnaker Release >  1.25.2 for the most recent
 version of Spinnaker components. For tracking of Docker artifacts and integration with CI (i.e. Jenkins),

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ pf4jVersion=3.5.0
 korkVersion=7.107.0
 orcaVersion=8.16.0
 kotlinVersion=1.4.21
-keelVersion=0.195.0
+keelVersion=0.197.0
 clouddriverVersion=5.72.1

--- a/k8s-plugin-keel/src/test/kotlin/com/amazon/spinnaker/keel/tests/K8sJobEvaluatorTest.kt
+++ b/k8s-plugin-keel/src/test/kotlin/com/amazon/spinnaker/keel/tests/K8sJobEvaluatorTest.kt
@@ -26,7 +26,7 @@ import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.orca.ExecutionDetailResponse
-import com.netflix.spinnaker.keel.orca.OrcaExecutionStatus
+import com.netflix.spinnaker.keel.api.TaskStatus
 import com.netflix.spinnaker.keel.orca.OrcaService
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
@@ -125,7 +125,7 @@ internal class K8sJobEvaluatorTest : JUnit5Minutests {
                 coEvery {
                     orcaService.getOrchestrationExecution("123", "keel-service-account")
                 } returns ExecutionDetailResponse(
-                    "123", "somename", "fnord", Instant.now(), null, null, OrcaExecutionStatus.SUCCEEDED
+                    "123", "somename", "fnord", Instant.now(), null, null, TaskStatus.SUCCEEDED
                 )
                 val actionState = ActionState(
                     ConstraintStatus.PENDING, Instant.now(), null, mapOf(
@@ -157,7 +157,7 @@ internal class K8sJobEvaluatorTest : JUnit5Minutests {
                 coEvery {
                     orcaService.getOrchestrationExecution("123", any())
                 } returns ExecutionDetailResponse(
-                    "123", "somename", "fnord", Instant.now(), null, null, OrcaExecutionStatus.RUNNING
+                    "123", "somename", "fnord", Instant.now(), null, null, TaskStatus.RUNNING
                 )
                 val actionState = ActionState(
                     ConstraintStatus.PASS, Instant.now(), null, mapOf("taskId" to "123", "taskName" to "somename")


### PR DESCRIPTION
replace OrcaExecutionStatus with TaskStatus - without this fix, the plugin doesn't work with <197 keel. this PR assumes that `0.0.10` will be tagged after :D