### PR TITLE
fix(job): remove `~` from job name

### DIFF
--- a/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/K8sConfig.kt
+++ b/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/K8sConfig.kt
@@ -61,6 +61,7 @@ const val FLUX_KUSTOMIZE_API_VERSION: String = "kustomize.toolkit.fluxcd.io/v1be
 const val FLUX_KUSTOMIZE_KIND: String = "Kustomization"
 const val FLUX_SECRETS_TOKEN_USERNAME: String = "token-user"
 const val FLUX_SOURCE_API_VERSION: String = "source.toolkit.fluxcd.io/v1beta1"
+const val K8S_INVALID_CHARACTER_REGEX = "[^\\.\\-a-z0-9]"
 
 const val VERIFICATION_K8S_JOB_V1: String = "k8s/job@v1"
 const val VERIFICATION_K8S_TYPE: String = "runJobManifest"

--- a/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/verificationEvaluator/K8sJobEvaluator.kt
+++ b/k8s-plugin-keel/src/main/kotlin/com/amazon/spinnaker/keel/k8s/verificationEvaluator/K8sJobEvaluator.kt
@@ -35,6 +35,7 @@ class K8sJobEvaluator(
     private val orcaService: OrcaService
 ) : VerificationEvaluator<K8sJobVerification> {
     private val log by lazy { LoggerFactory.getLogger(javaClass) }
+    private val re = Regex(K8S_INVALID_CHARACTER_REGEX)
     override val supportedVerification =
         VERIFICATION_K8S_JOB_V1 to K8sJobVerification::class.java
 
@@ -133,7 +134,7 @@ class K8sJobEvaluator(
         }
         metadata.remove(NAME)
         if (!metadata.containsKey(GENERATE_NAME)) {
-            var generateName = "verify-$application-$environment-$version"
+            var generateName = validK8sName("verify-$application-$environment-$version")
             verification.jobNamePrefix?.let {
                 generateName = "$it-$generateName"
             }
@@ -173,8 +174,12 @@ class K8sJobEvaluator(
         }
         // apply verifyWith specific labels
         labels[VERIFICATION_ENVIRONMENT_LABEL] = environment
-        labels[VERIFICATION_ARTIFACT_LABEL] = artifactVersion
+        labels[VERIFICATION_ARTIFACT_LABEL] = validK8sName(artifactVersion)
 
         metadata[LABELS] = labels
+    }
+
+    private fun validK8sName(k8sName: String): String {
+        return re.replace(k8sName, "-")
     }
 }


### PR DESCRIPTION
fixes https://github.com/nimakaviani/managed-delivery-k8s-plugin/issues/95
replace `~` with `-` in k8s job names.