### PR TITLE
remove bintray url

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven { url "https://dl.bintray.com/spinnaker/gradle/" }
+        mavenCentral()
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
I think bintray has been deprecated. Looks like gradle is looking for the plugin bundle package in bintray but not in maven central 